### PR TITLE
Script for configuring repository features

### DIFF
--- a/tools/cfg-repo-features.py
+++ b/tools/cfg-repo-features.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+__requires__ = ["click == 7.*", "PyGithub == 1.*"]
+from subprocess import check_output
+import click
+from github import Github
+
+
+@click.command()
+@click.argument("organization")
+def main(organization):
+    token = check_output(
+        ["git", "config", "hub.oauthtoken"], universal_newlines=True
+    ).strip()
+    gh = Github(token)
+    for repo in gh.get_organization(organization).get_repos():
+        print(repo.full_name)
+        repo.edit(has_issues=True, has_wiki=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script takes the name of a GitHub organization on the command line, reads a GitHub OAuth token from the Git config setting `hub.oauthtoken`, and configures all repositories in the organization to have issues enabled and wikis disabled.  (There is no way to disable pull requests.)

Closes #8.