### PR TITLE
RF: set only AUTHOR (not COMMITTER) and set it also for tags

### DIFF
--- a/tools/backups2datalad.py
+++ b/tools/backups2datalad.py
@@ -503,13 +503,14 @@ class DandiDatasetter:
             self.sync_dataset(dandiset, ds)
         else:
             branching = False
-        git(
-            "tag",
-            "-m",
-            f"Version {dandiset.version_id} of Dandiset {dandiset.identifier}",
-            dandiset.version_id,
-            commitish,
-        )
+        with custom_commit_date(dandiset.version.created):
+            git(
+                "tag",
+                "-m",
+                f"Version {dandiset.version_id} of Dandiset {dandiset.identifier}",
+                dandiset.version_id,
+                commitish,
+            )
         if branching:
             git("checkout", "master")
             git("branch", "-D", f"release-{dandiset.version_id}")

--- a/tools/backups2datalad.py
+++ b/tools/backups2datalad.py
@@ -666,8 +666,7 @@ def release(
 def custom_commit_date(dt: Optional[datetime]) -> Iterator[None]:
     if dt is not None:
         with envset("GIT_AUTHOR_DATE", str(dt)):
-            with envset("GIT_COMMITTER_DATE", str(dt)):
-                yield
+            yield
     else:
         yield
 

--- a/tools/backups2datalad.py
+++ b/tools/backups2datalad.py
@@ -377,19 +377,6 @@ class DandiDatasetter:
                 msgparts.append(f"{deleted} files deleted")
             if not msgparts:
                 msgparts.append("only some metadata updates")
-            last_commit_time = ensure_datetime(
-                readcmd(
-                    "git",
-                    "--no-pager",
-                    "show",
-                    "-s",
-                    "--format=%aI",
-                    "HEAD",
-                    cwd=dsdir,
-                )
-            )
-            if latest_mtime is not None and last_commit_time > latest_mtime:
-                latest_mtime = last_commit_time
             with custom_commit_date(latest_mtime):
                 ds.save(message=f"[backups2datalad] {', '.join(msgparts)}")
             return True


### PR DESCRIPTION
Instead of filing an issue, decided to just kick start the PR.

This way we would gain ability to have two dates -- as we discovered when it was modified in dandi-api (AUTHOR date), and then whenever we committed (COMMITTER)

- [x] I think with this we can simplify the logic and do not bother about "linear time forward" progression in the draft, committer date will be the one to rely on to check when was actually committed
- [x] `--before` for release commit discovery -- didn't check which date it uses, might need tune up to accomplish the desired need to base it on AUTHOR date?