### PR TITLE
BF: do not use date and -n1 with rev-list -- get ones directly from the candidates[0]

### DIFF
--- a/tools/backups2datalad.py
+++ b/tools/backups2datalad.py
@@ -87,6 +87,7 @@ class DandiDatasetter:
     force: Optional[str] = None
     content_url_regex: str = r"amazonaws.com/.*blobs/"
     s3bucket: str = "dandiarchive"
+    enable_tags: bool = True
 
     def update_from_backup(
         self,
@@ -442,6 +443,8 @@ class DandiDatasetter:
         return urlunparse(urlbits._replace(query=f"versionId={s3meta['VersionId']}"))
 
     def tag_releases(self, dandiset: RemoteDandiset, ds: Dataset, push: bool) -> None:
+        if not self.enable_tags:
+            return
         log.info("Tagging releases for Dandiset %s", dandiset.identifier)
         versions = [v for v in dandiset.get_versions() if v.identifier != "draft"]
         for v in versions:
@@ -513,23 +516,26 @@ class DandiDatasetter:
         candidates: List[str]
         if commitish is None:
             candidates = []
-            candidates.append(
-                readcmd(
-                    "git",
-                    "rev-list",
-                    f"--before={dandiset.version.created}",
-                    "-n1",
-                    "HEAD",
-                    cwd=repo,
-                )
-            )
+            # --before orders by commit date, not author date, so we need to
+            # filter commits ourselves.
+            commits = readcmd(
+                "git", "log", r"--grep=\[backups2datalad\]", "--format=%H %aI", cwd=repo
+            ).splitlines()
+            for cmt in commits:
+                chash, _, cdate = cmt.partition(" ")
+                ts = datetime.fromisoformat(cdate)
+                if ts <= dandiset.version.created:
+                    candidates.append(chash)
+                    break
             assert candidates, "we should have had at least a single commit"
             if (
-                # --reverse is applied after -n 1, so we cannot use it to get just one commit
-                # in chronological order after the first candidate, so we will get all and take last
+                # --reverse is applied after -n 1, so we cannot use it to get
+                # just one commit in chronological order after the first
+                # candidate, so we will get all and take last
                 cmt := readcmd(
                     "git",
                     "rev-list",
+                    r"--grep=\[backups2datalad\]",
                     f"{candidates[0]}..HEAD",
                     cwd=repo,
                 )

--- a/tools/backups2datalad.py
+++ b/tools/backups2datalad.py
@@ -523,17 +523,18 @@ class DandiDatasetter:
                     cwd=repo,
                 )
             )
+            assert candidates, "we should have had at least a single commit"
             if (
+                # --reverse is applied after -n 1, so we cannot use it to get just one commit
+                # in chronological order after the first candidate, so we will get all and take last
                 cmt := readcmd(
                     "git",
                     "rev-list",
-                    f"--after={dandiset.version.created}",
-                    "-n1",
-                    "HEAD",
+                    f"{candidates[0]}..HEAD",
                     cwd=repo,
                 )
             ) != "":
-                candidates.append(cmt)
+                candidates.append(cmt.split()[-1])
         else:
             candidates = [commitish]
         matching = list(filter(commit_has_assets, candidates))

--- a/tools/test_backups2datalad.py
+++ b/tools/test_backups2datalad.py
@@ -201,6 +201,46 @@ def test_1(text_dandiset: Dict[str, Any], tmp_path: Path) -> None:
     )
 
 
+def test_2(text_dandiset: Dict[str, Any], tmp_path: Path) -> None:
+    assetstore_path = tmp_path / "assetstore"
+    assetstore_path.mkdir()
+    (assetstore_path / "girder-assetstore").mkdir()
+    target_path = tmp_path / "target"
+    di = DandiDatasetter(
+        dandi_client=text_dandiset["client"],
+        assetstore_path=assetstore_path,
+        target_path=target_path,
+        ignore_errors=False,
+        content_url_regex=r".*/blobs/",
+        s3bucket="dandi-api-staging-dandisets",
+        enable_tags=False,
+    )
+
+    dandiset_id = text_dandiset["dandiset_id"]
+    di.update_from_backup([dandiset_id])
+    ds = Dataset(target_path / text_dandiset["dandiset_id"])
+
+    def readgit(*args: str) -> str:
+        return readcmd("git", *args, cwd=ds.path)
+
+    versions = []
+    for i in range(1, 4):
+        (text_dandiset["dspath"] / "counter.txt").write_text(f"{i}\n")
+        text_dandiset["reupload"]()
+        v = text_dandiset["dandiset"].publish().version
+        di.update_from_backup([dandiset_id])
+        assert readgit("tag") == ""
+        assert (ds.pathobj / "counter.txt").read_text() == f"{i}\n"
+        base = readgit("show", "-s", "--format=%H", "HEAD")
+        versions.append((v, base))
+
+    di.enable_tags = True
+    di.update_from_backup([dandiset_id])
+
+    for v, base in versions:
+        assert readgit("rev-parse", f"{v.identifier}^") == base
+
+
 def test_custom_commit_date(tmp_path: Path) -> None:
     ds = Dataset(str(tmp_path))
     ds.create(cfg_proc="text2git")


### PR DESCRIPTION
As I have mentioned before, not sure if 'date' criteria would be the most robust here,
and decided to just use the actual candidate, the child of which we should take.

With -n1, if there are multiple commits, we would be getting the latest on the HEAD
candidate, and not the one at the bottom.  As -n1 is applied before --reverse, --reverse
is of no help.  So I decided that we should just read all, split, and take the last one.

Compare, before:

![image](https://user-images.githubusercontent.com/39889/129956826-23ac099e-bfd6-4fd7-a29e-931032b1eb61.png)

to now:

![image](https://user-images.githubusercontent.com/39889/129957104-b73153f4-3a66-4f06-a8eb-b188d4ec6d50.png)

FTR -- how tested:
```
(dandisets) dandi@drogon:/mnt/backup/dandi/tmp/dandisets$ git -C 000029 reset --hard 3bef25dd90463d5da6dc48733bb7623048e067b6; git -C 000029 show --format=fuller | head
HEAD is now at 3bef25d [backups2datalad] only some metadata updates
commit 3bef25dd90463d5da6dc48733bb7623048e067b6
Author:     DANDI Meta-user <dandi@mit.edu>
AuthorDate: Fri Aug 6 17:22:47 2021 -0400
Commit:     DANDI Meta-user <dandi@mit.edu>
CommitDate: Fri Aug 6 17:22:47 2021 -0400

    [backups2datalad] only some metadata updates

diff --git a/.dandi/assets.json b/.dandi/assets.json
index 26c54cf..f55ccc9 100644
(dandisets) dandi@drogon:/mnt/backup/dandi/tmp/dandisets$ git -C 000029 tag | xargs git -C 000029 tag -d 
Deleted tag '0.210712.1903' (was de6b766)
Deleted tag '0.210730.1538' (was 9fbc589)
Deleted tag '0.210805.2047' (was ed17ccc)
Deleted tag '0.210806.1511' (was 55dd86a)
Deleted tag '0.210806.2112' (was b7a3ad8)

(dandisets) dandi@drogon:/mnt/backup/dandi/tmp/dandisets$ tools/backups2datalad.py -l INFO -J 5 --assetstore /mnt/backup/dandi/dandiarchive-s3-backup/ --target . update-from-backup 000029
...
```

- [ ] test_1 needs to be extended with having multiple draft states (so runs without tagging) before triggering a run which would get tagging done to verify correct deduction of the base commits in our current case where there could be multiple draft versions.

meanwhile I will test this on few other dandisets, but unlikely any is as good for this testing as 000029