### PR TITLE
Install a newer git-annex for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade --upgrade-strategy=eager nox
+          python -m pip install --upgrade --upgrade-strategy=eager datalad-installer nox
 
       - name: Install git-annex
-        run: sudo apt-get update && sudo apt-get install -y git-annex
+        run: datalad-installer --sudo ok neurodebian git-annex -m neurodebian
 
       - name: Install hdf5
         if: matrix.python-version == '3.9'


### PR DESCRIPTION
The version of git-annex on Ubuntu is not recent enough for DataLad, so we need to install via NeuroDebian instead in order for the CI to pass.