### PR TITLE
Add & apply pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+files: ^tools/
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black
+    rev: 21.9b0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-builtins
+          - flake8-unused-arguments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[flake8]
+doctests = True
+exclude = .*/,venv/
+hang-closing = False
+max-doc-length = 100
+max-line-length = 80
+unused-arguments-ignore-stub-functions = True
+select = C,B,B902,B950,E,E242,F,I,U100,W
+ignore = B005,E203,E262,E266,E501,I201,W503
+
+[isort]
+atomic = True
+force_sort_within_sections = True
+honor_noqa = True
+lines_between_sections = 1
+profile = black
+reverse_relative = True
+sort_relative_in_force_sorted_sections = True
+known_first_party = backups2datalad

--- a/tools/backups2datalad-cron
+++ b/tools/backups2datalad-cron
@@ -6,7 +6,7 @@ export PS1='$ '
 PS4='> '
 #set -x
 
-girderdir=/mnt/backup/dandi/dandiarchive-s3-backup/ 
+girderdir=/mnt/backup/dandi/dandiarchive-s3-backup/
 ds=$(dirname "$0")
 ds=$(dirname "$ds")
 
@@ -36,4 +36,4 @@ datalad save -m "CRON update" -d . 00*
 datalad push -J 5
 
 # we must be clean
-git diff --exit-code 
+git diff --exit-code

--- a/tools/cfg-repo-features.py
+++ b/tools/cfg-repo-features.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 __requires__ = ["click == 7.*", "PyGithub == 1.*"]
 from subprocess import check_output
+
 import click
 from github import Github
 

--- a/tools/chasseturls.py
+++ b/tools/chasseturls.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+
 import click
 from datalad.api import Dataset
 

--- a/tools/chdefbranch.py
+++ b/tools/chdefbranch.py
@@ -2,6 +2,7 @@
 __requires__ = ["click >= 8.0.1", "PyGithub ~= 1.53"]
 from pathlib import Path
 from subprocess import check_output, run
+
 import click
 from github import Github
 

--- a/tools/test_backups2datalad.py
+++ b/tools/test_backups2datalad.py
@@ -172,6 +172,7 @@ def test_1(text_dandiset: Dict[str, Any], tmp_path: Path) -> None:
         metadata = yaml_load(readgit("show", f"{vid}:{dandiset_metadata_file}"))
         assert metadata.get("doi")
 
+    text_dandiset["dandiset"].wait_until_valid()
     v1 = text_dandiset["dandiset"].publish().version
     version1 = v1.identifier
     di.update_from_backup([dandiset_id])
@@ -191,6 +192,7 @@ def test_1(text_dandiset: Dict[str, Any], tmp_path: Path) -> None:
         ds.pathobj / "new.txt"
     ).read_text() == "This file's contents were changed.\n"
 
+    text_dandiset["dandiset"].wait_until_valid()
     v2 = text_dandiset["dandiset"].publish().version
     version2 = v2.identifier
     di.update_from_backup([dandiset_id])
@@ -233,6 +235,7 @@ def test_2(text_dandiset: Dict[str, Any], tmp_path: Path) -> None:
     for i in range(1, 4):
         (text_dandiset["dspath"] / "counter.txt").write_text(f"{i}\n")
         text_dandiset["reupload"]()
+        text_dandiset["dandiset"].wait_until_valid()
         v = text_dandiset["dandiset"].publish().version
         di.update_from_backup([dandiset_id])
         assert readgit("tag") == ""

--- a/tools/use-new-urls.py
+++ b/tools/use-new-urls.py
@@ -65,7 +65,6 @@ class URLUpdater:
         if ds.repo.dirty:
             raise RuntimeError("Dirty repository; clean or save before running")
         ds.repo.always_commit = False
-        dsdir = ds.pathobj
         for a in self.dandi_client.get_dandiset_assets(
             dandiset_id, "draft", include_metadata=False
         ):


### PR DESCRIPTION
The `.pre-commit-config.yaml` hooks are configured to only be applied to files in `tools/`.