### PR TITLE
Deduplicate release number in repo descriptions

### DIFF
--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -184,7 +184,7 @@ class DandiDatasetter:
             desc = f"{contact}, {desc}"
         versions = sum(1 for v in dandiset.get_versions() if v.identifier != "draft")
         if versions:
-            desc = f"{versions} {quantify(versions, 'release')}, {desc}"
+            desc = f"{quantify(versions, 'release')}, {desc}"
         num_files = dandiset.version.asset_count
         size = naturalsize(dandiset.version.size)
         return f"{quantify(num_files, 'file')}, {size}, {desc}"


### PR DESCRIPTION
Fixes #101.

This fix can be applied to affected repositories by running `python3 -m backups2datalad update-github-metadata`.