### PR TITLE
Get Dandiset sizes from datasets; set superdataset description

### DIFF
--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -6,6 +6,7 @@ click-loglevel ~= 0.2
 dandi >= 0.31.0
 dandischema
 datalad
+ghrepo ~= 0.1
 httpx ~= 0.20.0
 humanize
 morecontext ~= 0.1

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -144,18 +144,12 @@ def update_from_backup(
     metavar="REGEX",
     type=re.compile,
 )
-@click.option(
-    "--gh-org",
-    help="GitHub organization under which repositories reside",
-    required=True,
-)
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
 def update_github_metadata(
     datasetter: DandiDatasetter,
     dandisets: Sequence[str],
     exclude: Optional[re.Pattern[str]],
-    gh_org: str,
 ) -> None:
     """
     Update the homepages and descriptions for the GitHub repositories for the
@@ -165,7 +159,7 @@ def update_github_metadata(
     `--target` must point to a clone of the superdataset in which every
     Dandiset subdataset is installed.
     """
-    datasetter.update_github_metadata(dandisets, exclude=exclude, gh_org=gh_org)
+    datasetter.update_github_metadata(dandisets, exclude=exclude)
 
 
 @main.command()

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -157,6 +157,14 @@ def update_github_metadata(
     exclude: Optional[re.Pattern[str]],
     gh_org: str,
 ) -> None:
+    """
+    Update the homepages and descriptions for the GitHub repositories for the
+    given Dandisets.  If all Dandisets are updated, the description for the
+    superdataset is set afterwards as well.
+
+    `--target` must point to a clone of the superdataset in which every
+    Dandiset subdataset is installed.
+    """
     datasetter.update_github_metadata(dandisets, exclude=exclude, gh_org=gh_org)
 
 

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -212,7 +212,12 @@ class DandiDatasetter:
         size = 0
         for filestat in ds.status(annex="basic"):
             path = Path(filestat["path"]).relative_to(ds.pathobj)
-            if path.parts[0] not in (".dandi", ".gitattributes"):
+            if path.parts[0] not in (
+                ".dandi",
+                ".datalad",
+                ".gitattributes",
+                dandiset_metadata_file,
+            ):
                 files += 1
                 size += filestat["bytesize"]
         return DandisetStats(files=files, size=size)


### PR DESCRIPTION
Closes #109.

The failing type-checks are fixed by #108.  ~See https://github.com/dandi/dandi-archive/issues/814 for the other failing tests.~

Running `python3 -m backups2datalad --target <superdataset path> update-github-metadata` against a copy of this repository in which every sub-dataset is installed (which `update-github-metadata` now requires; also, it no longer takes `--gh-org`) will update the descriptions for all repositories based on their committed assets and will also set the description for the superdataset.