### PR TITLE
Update for dandi/dandi-cli#853

### DIFF
--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -3,7 +3,7 @@
 async_generator ~= 1.10; python_version < '3.10'
 click >= 8.0.1
 click-loglevel ~= 0.2
-dandi >= 0.31.0
+dandi >= 0.36.0
 dandischema
 datalad
 ghrepo ~= 0.1

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -87,7 +87,7 @@ class Downloader(trio.abc.AsyncResource):
                     break
                 if downloading:
                     try:
-                        sha256_digest = asset.get_digest(DigestType.sha2_256)
+                        sha256_digest = asset.get_raw_digest(DigestType.sha2_256)
                     except NotFoundError:
                         log.info(
                             "%s: SHA256 has not been computed yet;"

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -12,7 +12,7 @@ import sys
 from typing import AsyncIterator, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
 
-from dandi.dandiapi import RemoteAsset, RemoteDandiset
+from dandi.dandiapi import AssetType, RemoteAsset, RemoteDandiset
 from dandi.exceptions import NotFoundError
 from dandischema.models import DigestType
 from datalad.api import Dataset
@@ -85,6 +85,11 @@ class Downloader(trio.abc.AsyncResource):
             async for asset in aia:
                 if asset is None:
                     break
+                if asset.asset_type == AssetType.ZARR:
+                    log.warning(
+                        "%s: Asset is a Zarr; abandoning this Dandiset", asset.path
+                    )
+                    downloading = False
                 if downloading:
                     try:
                         sha256_digest = asset.get_raw_digest(DigestType.sha2_256)

--- a/tools/setup.cfg
+++ b/tools/setup.cfg
@@ -3,6 +3,7 @@ addopts = --cov=backups2datalad --cov-config=setup.cfg --no-cov-on-fail
 filterwarnings =
     #error
     ignore:datalad.version module will be removed:DeprecationWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
 
 [coverage:run]

--- a/tools/test_backups2datalad.py
+++ b/tools/test_backups2datalad.py
@@ -68,8 +68,7 @@ def text_dandiset(
 
     def upload_dandiset(paths: Optional[List[str]] = None, **kwargs: Any) -> None:
         upload(
-            paths=paths or [],
-            dandiset_path=dspath,
+            paths=paths or [dspath],
             dandi_instance="dandi-staging",
             devel_debug=True,
             allow_any_path=True,


### PR DESCRIPTION
Rerun tests & merge only after dandi/dandi-cli#853 is merged & released.

Note that this only updates backups2datalad for the changes in the part of the API that it already uses; further changes will be needed to add Zarr support to the backup script.