### PR TITLE
Add `result_renderer=None` to `ds.status()` calls

### DIFF
--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -359,7 +359,9 @@ async def async_assets(
                         "%s downloaded for this version segment; committing",
                         quantify(dm.report.downloaded, "asset"),
                     )
-                    if any(r["state"] != "clean" for r in ds.status()):
+                    if any(
+                        r["state"] != "clean" for r in ds.status(result_renderer=None)
+                    ):
                         log.info("Commiting changes")
                         assert dm.last_timestamp is not None
                         with custom_commit_date(dm.last_timestamp):

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -150,7 +150,7 @@ class DandiDatasetter:
                 syncer.prune_deleted()
                 syncer.dump_asset_metadata()
             assert syncer.report is not None
-            if any(r["state"] != "clean" for r in ds.status()):
+            if any(r["state"] != "clean" for r in ds.status(result_renderer=None)):
                 log.info("Commiting changes")
                 with custom_commit_date(dandiset.version.modified):
                     ds.save(message=syncer.get_commit_message())
@@ -211,7 +211,7 @@ class DandiDatasetter:
     def get_dandiset_stats(self, ds: Dataset) -> DandisetStats:
         files = 0
         size = 0
-        for filestat in ds.status(annex="basic"):
+        for filestat in ds.status(annex="basic", result_renderer=None):
             path = Path(filestat["path"]).relative_to(ds.pathobj)
             if path.parts[0] not in (
                 ".dandi",


### PR DESCRIPTION
Closes #117.