### PR TITLE
Limit the number of Zarrs processed at once; increase HTTP retries to 10

### DIFF
--- a/tools/backups2datalad/consts.py
+++ b/tools/backups2datalad/consts.py
@@ -5,3 +5,6 @@ DANDISETS_REMOTE_UUID = "727f466f-60c3-4778-90b2-b2332856c2f8"
 
 ZARRS_REMOTE_PREFIX = "dandi-dandizarrs/annexstore"
 ZARRS_REMOTE_UUID = "727f466f-60c3-4778-90b2-b2332856c2f9"
+
+# Maximum number of Zarrs to process at once
+ZARR_LIMIT = 32

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -425,7 +425,7 @@ def exp_wait(
 
 
 async def arequest(client: httpx.AsyncClient, method: str, url: str) -> httpx.Response:
-    waits = exp_wait(attempts=5, base=1.25, multiplier=1.25)
+    waits = exp_wait(attempts=10, base=1.25, multiplier=1.25)
     while True:
         try:
             r = await client.request(method, url, follow_redirects=True)

--- a/tools/test_backups2datalad/test_zarr.py
+++ b/tools/test_backups2datalad/test_zarr.py
@@ -63,7 +63,7 @@ def test_sync_zarr(new_dandiset: SampleDandiset, tmp_path: Path) -> None:
     asset = new_dandiset.dandiset.get_asset_by_path("sample.zarr")
     checksum = asset.get_digest().value
     config = Config(s3bucket="dandi-api-staging-dandisets")
-    trio.run(sync_zarr, asset, checksum, tmp_path, config)
+    trio.run(sync_zarr, asset, checksum, tmp_path, config, trio.CapacityLimiter(1))
     check_zarr(zarr_path, Dataset(tmp_path), checksum)
 
 


### PR DESCRIPTION
Will test this out on 000108 on drogon and report back.

EDIT: I started a backup of 000108 from scratch under `/mnt/backups/tmp/jwodder` on drogon, and it's been running for an hour without error so far.