### PR TITLE
BF: add f for an f-string

### DIFF
--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -415,7 +415,7 @@ async def async_assets(
                         log.info("Zarr asset added at %s; cloning", asset_path)
                         dm.report.added += 1
                         if config.zarr_gh_org is not None:
-                            src = "https://github.com/{config.zarr_gh_org}/{zarr_id}"
+                            src = f"https://github.com/{config.zarr_gh_org}/{zarr_id}"
                         else:
                             assert config.zarr_target is not None
                             src = str(config.zarr_target / zarr_id)


### PR DESCRIPTION
I got my test run to crash due to this with following traceback, and I guess
it is this fix which is needed.

	(dandisets) dandi@drogon:/mnt/backup/dandi/dandisets$ python -m tools.backups2datalad -l WARNING -J 5 --target /mnt/backup/dandi/dandisets update-from-backup --zarr-target /mnt/backup/dandi/dandizarrs --backup-remote dandi-dandisets-dropbox --zarr-backup-remote dandi-dandizarrs-dropbox --gh-org dandisets --zarr-gh-org dandizarrs -e '000108$'
	A newer version (0.39.5) of dandi/dandi-cli is available. You are using 0.36.0
	whereis: 1319 failed
	2022-05-09T13:42:07-0400 [WARNING ] backups2datalad git-annex whereis command exited with return code 1
	[ERROR  ] Failed to clone from any candidate source URL. Encountered errors per each url were:
	| - https://github.com/{config.zarr_gh_org}/{zarr_id}
	  CommandError: 'git -c diff.ignoreSubmodules=none clone --progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}' /mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' failed with exitcode 128 [err: 'Cloning into '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...
	fatal: unable to access 'https://github.com/{config.zarr_gh_org}/{zarr_id}/': The requested URL returned error: 400']
	- https://github.com/{config.zarr_gh_org}/{zarr_id}/.git
	  CommandError: 'git -c diff.ignoreSubmodules=none clone --progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git' /mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' failed with exitcode 128 [err: 'Cloning into '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...
	remote: Not Found
	fatal: repository 'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git/' not found'] [install(/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff)]
	2022-05-09T13:42:22-0400 [ERROR  ] datalad.core.distributed.clone Failed to clone from any candidate source URL. Encountered errors per each url were:
	| - https://github.com/{config.zarr_gh_org}/{zarr_id}
	  CommandError: 'git -c diff.ignoreSubmodules=none clone --progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}' /mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' failed with exitcode 128 [err: 'Cloning into '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...
	fatal: unable to access 'https://github.com/{config.zarr_gh_org}/{zarr_id}/': The requested URL returned error: 400']
	- https://github.com/{config.zarr_gh_org}/{zarr_id}/.git
	  CommandError: 'git -c diff.ignoreSubmodules=none clone --progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git' /mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' failed with exitcode 128 [err: 'Cloning into '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...
	remote: Not Found
	fatal: repository 'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git/' not found'] [install(/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff)]
	2022-05-09T13:42:22-0400 [ERROR   ] backups2datalad Operation failed with exception:
	Traceback (most recent call last):
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/util.py", line 318, in dandi_logging
		yield logfile
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/datasetter.py", line 145, in sync_dataset
		syncer.sync_assets()
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/syncer.py", line 36, in sync_assets
		self.report = trio.run(
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_core/_run.py", line 1946, in run
		raise runner.main_task_outcome.error
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/asyncer.py", line 422, in async_assets
		await trio.to_thread.run_sync(
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 214, in to_thread_run_sync
		return await trio.lowlevel.wait_task_rescheduled(abort)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_core/_traps.py", line 166, in wait_task_rescheduled
		return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/outcome/_impl.py", line 138, in unwrap
		raise captured_error
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 160, in do_release_then_return_result
		return result.unwrap()
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/outcome/_impl.py", line 138, in unwrap
		raise captured_error
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 174, in worker_fn
		ret = sync_fn(*args)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 486, in eval_func
		return return_func(generator_func)(*args, **kwargs)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 474, in return_func
		results = list(results)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 459, in generator_func
		raise IncompleteResultsError(
	datalad.support.exceptions.IncompleteResultsError: Command did not complete successfully. 1 failed:
	[{'action': 'install',
	  'message': ('Failed to clone from any candidate source URL. Encountered '
				  'errors per each url were:\n'
				  '- %s',
				  'https://github.com/{config.zarr_gh_org}/{zarr_id}\n'
				  "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
				  "--progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}' "
				  "/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' "
				  "failed with exitcode 128 [err: 'Cloning into "
				  "'/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...\n"
				  'fatal: unable to access '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/': The "
				  "requested URL returned error: 400']\n"
				  '- https://github.com/{config.zarr_gh_org}/{zarr_id}/.git\n'
				  "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
				  '--progress '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git' "
				  "/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' "
				  "failed with exitcode 128 [err: 'Cloning into "
				  "'/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...\n"
				  'remote: Not Found\n'
				  'fatal: repository '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git/' not "
				  "found']"),
	  'path': '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff',
	  'source_url': 'https://github.com/{config.zarr_gh_org}/{zarr_id}',
	  'status': 'error',
	  'type': 'dataset'}]
	Traceback (most recent call last):
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/runpy.py", line 194, in _run_module_as_main
		return _run_code(code, main_globals, None,
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/runpy.py", line 87, in _run_code
		exec(code, run_globals)
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/__main__.py", line 311, in <module>
		main()
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/core.py", line 1137, in __call__
		return self.main(*args, **kwargs)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/core.py", line 1062, in main
		rv = self.invoke(ctx)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/core.py", line 1668, in invoke
		return _process_result(sub_ctx.command.invoke(sub_ctx))
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
		return ctx.invoke(self.callback, **ctx.params)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/core.py", line 763, in invoke
		return __callback(*args, **kwargs)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/click/decorators.py", line 38, in new_func
		return f(get_current_context().obj, *args, **kwargs)
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/__main__.py", line 159, in update_from_backup
		datasetter.update_from_backup(dandisets, exclude=exclude)
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/datasetter.py", line 76, in update_from_backup
		changed = self.sync_dataset(d, ds)
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/datasetter.py", line 145, in sync_dataset
		syncer.sync_assets()
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/syncer.py", line 36, in sync_assets
		self.report = trio.run(
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_core/_run.py", line 1946, in run
		raise runner.main_task_outcome.error
	  File "/mnt/backup/dandi/dandisets/tools/backups2datalad/asyncer.py", line 422, in async_assets
		await trio.to_thread.run_sync(
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 214, in to_thread_run_sync
		return await trio.lowlevel.wait_task_rescheduled(abort)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_core/_traps.py", line 166, in wait_task_rescheduled
		return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/outcome/_impl.py", line 138, in unwrap
		raise captured_error
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 160, in do_release_then_return_result
		return result.unwrap()
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/outcome/_impl.py", line 138, in unwrap
		raise captured_error
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/trio/_threads.py", line 174, in worker_fn
		ret = sync_fn(*args)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 486, in eval_func
		return return_func(generator_func)(*args, **kwargs)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 474, in return_func
		results = list(results)
	  File "/home/dandi/miniconda3/envs/dandisets/lib/python3.8/site-packages/datalad/interface/utils.py", line 459, in generator_func
		raise IncompleteResultsError(
	datalad.support.exceptions.IncompleteResultsError: Command did not complete successfully. 1 failed:
	[{'action': 'install',
	  'message': ('Failed to clone from any candidate source URL. Encountered '
				  'errors per each url were:\n'
				  '- %s',
				  'https://github.com/{config.zarr_gh_org}/{zarr_id}\n'
				  "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
				  "--progress 'https://github.com/{config.zarr_gh_org}/{zarr_id}' "
				  "/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' "
				  "failed with exitcode 128 [err: 'Cloning into "
				  "'/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...\n"
				  'fatal: unable to access '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/': The "
				  "requested URL returned error: 400']\n"
				  '- https://github.com/{config.zarr_gh_org}/{zarr_id}/.git\n'
				  "  CommandError: 'git -c diff.ignoreSubmodules=none clone "
				  '--progress '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git' "
				  "/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff' "
				  "failed with exitcode 128 [err: 'Cloning into "
				  "'/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff'...\n"
				  'remote: Not Found\n'
				  'fatal: repository '
				  "'https://github.com/{config.zarr_gh_org}/{zarr_id}/.git/' not "
				  "found']"),
	  'path': '/mnt/backup/dandi/dandisets/000243/sub-S01/anat/sub-S01_T2w.ngff',
	  'source_url': 'https://github.com/{config.zarr_gh_org}/{zarr_id}',
	  'status': 'error',
	  'type': 'dataset'}]