### PR TITLE
Update for datalad 0.16

### DIFF
--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -6,7 +6,7 @@ click >= 8.0.1
 click-loglevel ~= 0.2
 dandi >= 0.36.0
 dandischema
-datalad
+datalad >= 0.16.0
 ghrepo ~= 0.1
 httpx ~= 0.22.0
 humanize

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -64,7 +64,7 @@ class DandiDatasetter:
         dandiset_ids: Sequence[str] = (),
         exclude: Optional[re.Pattern[str]] = None,
     ) -> None:
-        datalad.cfg.set("datalad.repo.backend", "SHA256E", where="override")
+        datalad.cfg.set("datalad.repo.backend", "SHA256E", scope="override")
         superds = self.ensure_superdataset()
         to_save: List[str] = []
         ds_stats: List[DandisetStats] = []

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -470,14 +470,14 @@ def init_dataset(
 ) -> None:
     log.info("Creating dataset for %s", desc)
     try:
-        datalad.cfg.set("datalad.repo.backend", backend, where="override")
+        datalad.cfg.set("datalad.repo.backend", backend, scope="override")
         with custom_commit_date(commit_date):
             with envset(
                 "GIT_CONFIG_PARAMETERS", f"'init.defaultBranch={DEFAULT_BRANCH}'"
             ):
                 ds.create(cfg_proc=cfg_proc)
     finally:
-        datalad.cfg.unset("datalad.repo.backend", where="override")
+        datalad.cfg.unset("datalad.repo.backend", scope="override")
     if backup_remote is not None:
         ds.repo.init_remote(
             backup_remote.name,
@@ -517,13 +517,13 @@ def create_github_sibling(
         ds.config.set(
             "remote.github.pushurl",
             f"git@github.com:{owner}/{name}.git",
-            where="local",
+            scope="local",
         )
-        ds.config.set(f"branch.{DEFAULT_BRANCH}.remote", "github", where="local")
+        ds.config.set(f"branch.{DEFAULT_BRANCH}.remote", "github", scope="local")
         ds.config.set(
             f"branch.{DEFAULT_BRANCH}.merge",
             f"refs/heads/{DEFAULT_BRANCH}",
-            where="local",
+            scope="local",
         )
         return True
     else:

--- a/tools/test_backups2datalad/test_zarr.py
+++ b/tools/test_backups2datalad/test_zarr.py
@@ -9,7 +9,6 @@ from dandi.utils import find_files
 from datalad.api import Dataset
 from datalad.tests.utils import assert_repo_status
 import numpy as np
-import pytest
 from test_util import GitRepo
 import trio
 import zarr
@@ -127,7 +126,6 @@ def test_backup_zarr(new_dandiset: SampleDandiset, tmp_path: Path) -> None:
     assert zarrgit.get_commit_count() == 4
 
 
-@pytest.mark.skip(reason="https://github.com/datalad/datalad/issues/6558")
 def test_backup_zarr_entry_conflicts(
     new_dandiset: SampleDandiset, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
This addresses a warning about `where` being deprecated and also un-skips a test that was being skipped due to a bug in DataLad.

Testing still encounters some warnings of the form "`datalad/core/local/status.py:375: DeprecationWarning: status(repor_filetype=) no longer supported, and will be removed in a future release`", but I'm not sure what's causing them, since this code does not use `repor_filetype`/`repr_filetype` anywhere.