### PR TITLE
BF: in zarr.save_and_push do not push data

### DIFF
--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -490,5 +490,5 @@ def save_and_push(
     log.debug("Zarr %s: Commit made", zarr_id)
     if push:
         log.debug("Zarr %s: Pushing to GitHub", zarr_id)
-        ds.push(to="github", jobs=jobs)
+        ds.push(to="github", jobs=jobs, data="nothing")
         log.debug("Zarr %s: Finished pushing to GitHub", zarr_id)


### PR DESCRIPTION
this function, as far as I could tell, is used only within
"release" and "update_from_backup". release -- I think it was used
once in the past and otherwise not used ATM.  "update_from_backup" -
should not push the data -- pushing (well -- moving) data is the job of
populate-* jobs.

Besides avoiding data transfer, it is more of avoiding interference
between  unintended data transfer  here and   "populate-zarrs" job
which first "get"s all the data, and if that push happens to come
during that get/move -- odd things happen.

Fixes #170