### PR TITLE
Do not push data in update_from_backup (and even minting releases)

### DIFF
--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -81,7 +81,7 @@ class DandiDatasetter:
             if self.config.gh_org is not None:
                 if changed:
                     log.info("Pushing to sibling")
-                    ds.push(to="github", jobs=self.config.jobs)
+                    ds.push(to="github", jobs=self.config.jobs, data="nothing")
                 ds_stats.append(self.set_dandiset_gh_metadata(d, ds))
         log.debug("Committing superdataset")
         superds.save(message="CRON update", path=to_save)
@@ -321,7 +321,7 @@ class DandiDatasetter:
                     check=True,
                 )
             if push:
-                ds.push(to="github", jobs=self.config.jobs)
+                ds.push(to="github", jobs=self.config.jobs, data="nothing")
 
     def mkrelease(
         self,


### PR DESCRIPTION
Follow up to recent similar change for zarrs.  We are moving
moving the data into populate* jobs, no data should be pushed in
regular update where we mint it all from metadata

Fixes #180

Let's see if tests are effected somehow