### PR TITLE
BF: log Running command exactly as executed

### DIFF
--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -354,11 +354,12 @@ async def populate(dirpath: Path, backup_remote: str, desc: str, jobs: int) -> N
 
 
 async def call_annex_json(cmd: str, *args: str, path: Path) -> None:
-    log.debug("Running git-annex %s", shlex.join(args))
+    cmd_full = ["git-annex", cmd, *args, "--json", "--json-error-messages"]
+    log.debug("Running %s", shlex.join(cmd_full))
     success = 0
     failed = 0
     async with await anyio.open_process(
-        ["git-annex", cmd, *args, "--json", "--json-error-messages"],
+        cmd_full,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         cwd=path,


### PR DESCRIPTION
spotted logs like

```
2022-06-07T13:23:28-0400 [INFO    ] backups2datalad Moving files for Zarr 1825d3a0-81f4-4fe3-923b-a6149d059601 to backup remote
2022-06-07T13:23:28-0400 [DEBUG   ] backups2datalad Running git-annex -c annex.retry=3 --jobs 5 --to dandi-dandizarrs-dropbox
```
which confused me on how they could potentially work since `move` was missing.

Logging for which command is running was lacking command, and apparently
--json* flags.  To ease debugging, logged command better has all the options
as-is.
