### PR TITLE
Make backups and population asynchronously parallel

### DIFF
--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -3,7 +3,7 @@
 aiobotocore
 anyio ~= 3.6
 async_generator ~= 1.10; python_version < '3.10'
-click >= 8.0.1
+asyncclick >= 8.0.1
 click-loglevel ~= 0.2
 dandi >= 0.36.0
 dandischema
@@ -12,7 +12,5 @@ ghrepo ~= 0.1
 httpx ~= 0.22.0
 humanize
 identify ~= 2.0
-morecontext ~= 0.1
 packaging
 pydantic ~= 1.8
-PyGithub ~= 1.53

--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -4,7 +4,6 @@ aiobotocore
 anyio ~= 3.6
 async_generator ~= 1.10; python_version < '3.10'
 asyncclick >= 8.0.1
-click-loglevel ~= 0.2
 dandi >= 0.36.0
 dandischema
 datalad >= 0.16.0

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -112,6 +112,7 @@ async def main(
     default=None,
     help="Enable/disable creation of tags for releases  [default: enabled]",
 )
+@click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
 async def update_from_backup(
@@ -121,6 +122,7 @@ async def update_from_backup(
     tags: Optional[bool],
     asset_filter: Optional[re.Pattern[str]],
     force: Optional[str],
+    workers: Optional[int],
 ) -> None:
     async with datasetter:
         if asset_filter is not None:
@@ -129,6 +131,8 @@ async def update_from_backup(
             datasetter.config.force = force
         if tags is not None:
             datasetter.config.enable_tags = tags
+        if workers is not None:
+            datasetter.config.workers = workers
         await datasetter.update_from_backup(dandisets, exclude=exclude)
 
 

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -14,7 +14,7 @@ from datalad.api import Dataset
 
 from .adandi import AsyncDandiClient
 from .adataset import AsyncDataset
-from .aioutil import aiter, open_git_annex, pool_amap
+from .aioutil import open_git_annex, pool_amap
 from .config import BackupConfig
 from .datasetter import DandiDatasetter
 from .logging import log
@@ -349,7 +349,7 @@ async def call_annex_json(cmd: str, *args: str, path: Path) -> None:
         use_stdin=False,
         path=path,
     ) as p:
-        async for line in aiter(p):
+        async for line in p:
             data = json.loads(line)
             if data["success"]:
                 success += 1

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -11,12 +11,13 @@ import sys
 from typing import AsyncIterable, Optional, Sequence
 
 import anyio
-import click
+import asyncclick as click
 from click_loglevel import LogLevel
 from dandi.consts import DANDISET_ID_REGEX
 from dandi.dandiapi import DandiAPIClient
 from datalad.api import Dataset
 
+from .adataset import AsyncDataset
 from .aioutil import TextProcess, aiter, pool_amap
 from .config import Config
 from .datasetter import DandiDatasetter
@@ -54,7 +55,7 @@ from .util import format_errors, log, pdb_excepthook, quantify
     help="Log backups2datalad at DEBUG and all other loggers at INFO",
 )
 @click.pass_context
-def main(
+async def main(
     ctx: click.Context,
     jobs: Optional[int],
     log_level: int,
@@ -72,9 +73,7 @@ def main(
     if jobs is not None:
         cfg.jobs = jobs
     ctx.obj = DandiDatasetter(
-        dandi_client=ctx.with_resource(
-            DandiAPIClient.for_dandi_instance(cfg.dandi_instance)
-        ),
+        dandi_client=DandiAPIClient.for_dandi_instance(cfg.dandi_instance),
         config=cfg,
     )
     if pdb:
@@ -87,7 +86,7 @@ def main(
         datefmt="%Y-%m-%dT%H:%M:%S%z",
         level=log_level,
     )
-    ctx.obj.debug_logfile()
+    await ctx.obj.debug_logfile()
 
 
 @main.command()
@@ -117,7 +116,7 @@ def main(
 )
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
-def update_from_backup(
+async def update_from_backup(
     datasetter: DandiDatasetter,
     dandisets: Sequence[str],
     exclude: Optional[re.Pattern[str]],
@@ -125,13 +124,14 @@ def update_from_backup(
     asset_filter: Optional[re.Pattern[str]],
     force: Optional[str],
 ) -> None:
-    if asset_filter is not None:
-        datasetter.config.asset_filter = asset_filter
-    if force is not None:
-        datasetter.config.force = force
-    if tags is not None:
-        datasetter.config.enable_tags = tags
-    datasetter.update_from_backup(dandisets, exclude=exclude)
+    async with datasetter:
+        if asset_filter is not None:
+            datasetter.config.asset_filter = asset_filter
+        if force is not None:
+            datasetter.config.force = force
+        if tags is not None:
+            datasetter.config.enable_tags = tags
+        await datasetter.update_from_backup(dandisets, exclude=exclude)
 
 
 @main.command()
@@ -144,7 +144,7 @@ def update_from_backup(
 )
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
-def update_github_metadata(
+async def update_github_metadata(
     datasetter: DandiDatasetter,
     dandisets: Sequence[str],
     exclude: Optional[re.Pattern[str]],
@@ -157,7 +157,8 @@ def update_github_metadata(
     `--target` must point to a clone of the superdataset in which every
     Dandiset subdataset is installed.
     """
-    datasetter.update_github_metadata(dandisets, exclude=exclude)
+    async with datasetter:
+        await datasetter.update_github_metadata(dandisets, exclude=exclude)
 
 
 @main.command()
@@ -178,7 +179,7 @@ def update_github_metadata(
 @click.argument("dandiset")
 @click.argument("version")
 @click.pass_obj
-def release(
+async def release(
     datasetter: DandiDatasetter,
     dandiset: str,
     version: str,
@@ -187,15 +188,18 @@ def release(
     asset_filter: Optional[re.Pattern[str]],
     force: Optional[str],
 ) -> None:
-    if asset_filter is not None:
-        datasetter.config.asset_filter = asset_filter
-    if force is not None:
-        datasetter.config.force = force
-    dandiset_obj = datasetter.dandi_client.get_dandiset(dandiset, version)
-    dataset = Dataset(datasetter.config.dandiset_root / dandiset)
-    datasetter.mkrelease(dandiset_obj, dataset, commitish=commitish, push=push)
-    if push:
-        dataset.push(to="github", jobs=datasetter.config.jobs)
+    async with datasetter:
+        if asset_filter is not None:
+            datasetter.config.asset_filter = asset_filter
+        if force is not None:
+            datasetter.config.force = force
+        dandiset_obj = await datasetter.dandi_client.aget_dandiset(dandiset, version)
+        dataset = AsyncDataset(datasetter.config.dandiset_root / dandiset)
+        await datasetter.mkrelease(
+            dandiset_obj, dataset, commitish=commitish, push=push
+        )
+        if push:
+            await dataset.push(to="github", jobs=datasetter.config.jobs)
 
 
 @main.command("populate")
@@ -209,87 +213,87 @@ def release(
 @click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
-def populate_cmd(
+async def populate_cmd(
     datasetter: DandiDatasetter,
     dandisets: Sequence[str],
     exclude: Optional[re.Pattern[str]],
     workers: Optional[int],
 ) -> None:
-    if (r := datasetter.config.dandisets.remote) is not None:
-        backup_remote = r.name
-    else:
-        raise click.UsageError("dandisets.remote not set in config file")
-    if workers is not None:
-        datasetter.config.workers = workers
-    if dandisets:
-        diriter = (datasetter.config.dandiset_root / d for d in dandisets)
-    else:
-        diriter = datasetter.config.dandiset_root.iterdir()
-    dirs: list[Path] = []
-    for p in diriter:
-        if p.is_dir() and re.fullmatch(DANDISET_ID_REGEX, p.name):
-            if exclude is not None and exclude.search(p.name):
-                log.debug("Skipping dandiset %s", p.name)
-            else:
-                dirs.append(p)
+    async with datasetter:
+        if (r := datasetter.config.dandisets.remote) is not None:
+            backup_remote = r.name
         else:
-            log.debug("Skipping non-Dandiset node %s", p.name)
-    report = anyio.run(
-        pool_amap,
-        partial(
-            populate,
-            backup_remote=backup_remote,
-            pathtype="Dandiset",
-            jobs=datasetter.config.jobs,
-        ),
-        afilter_installed(dirs),
-        datasetter.config.workers,
-    )
-    if report.failed:
-        sys.exit(f"{quantify(len(report.failed), 'populate job')} failed")
+            raise click.UsageError("dandisets.remote not set in config file")
+        if workers is not None:
+            datasetter.config.workers = workers
+        if dandisets:
+            diriter = (datasetter.config.dandiset_root / d for d in dandisets)
+        else:
+            diriter = datasetter.config.dandiset_root.iterdir()
+        dirs: list[Path] = []
+        for p in diriter:
+            if p.is_dir() and re.fullmatch(DANDISET_ID_REGEX, p.name):
+                if exclude is not None and exclude.search(p.name):
+                    log.debug("Skipping dandiset %s", p.name)
+                else:
+                    dirs.append(p)
+            else:
+                log.debug("Skipping non-Dandiset node %s", p.name)
+        report = await pool_amap(
+            partial(
+                populate,
+                backup_remote=backup_remote,
+                pathtype="Dandiset",
+                jobs=datasetter.config.jobs,
+            ),
+            afilter_installed(dirs),
+            workers=datasetter.config.workers,
+        )
+        if report.failed:
+            sys.exit(f"{quantify(len(report.failed), 'populate job')} failed")
 
 
 @main.command()
 @click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
 @click.argument("zarrs", nargs=-1)
 @click.pass_obj
-def populate_zarrs(
+async def populate_zarrs(
     datasetter: DandiDatasetter, zarrs: Sequence[str], workers: Optional[int]
 ) -> None:
-    zcfg = datasetter.config.zarrs
-    if zcfg is None:
-        raise click.UsageError("Zarr backups not configured in config file")
-    if (r := zcfg.remote) is not None:
-        backup_remote = r.name
-    else:
-        raise click.UsageError("zarrs.remote not set in config file")
-    if workers is not None:
-        datasetter.config.workers = workers
-    zarr_root = datasetter.config.zarr_root
-    assert zarr_root is not None
-    if zarrs:
-        diriter = (zarr_root / z for z in zarrs)
-    else:
-        diriter = zarr_root.iterdir()
-    dirs: list[Path] = []
-    for p in diriter:
-        if p.is_dir() and p.name not in (".git", ".datalad"):
-            dirs.append(p)
+    async with datasetter:
+        zcfg = datasetter.config.zarrs
+        if zcfg is None:
+            raise click.UsageError("Zarr backups not configured in config file")
+        if (r := zcfg.remote) is not None:
+            backup_remote = r.name
         else:
-            log.debug("Skipping non-Zarr node %s", p.name)
-    report = anyio.run(
-        pool_amap,
-        partial(
-            populate,
-            backup_remote=backup_remote,
-            pathtype="Zarr",
-            jobs=datasetter.config.jobs,
-        ),
-        afilter_installed(dirs),
-        datasetter.config.workers,
-    )
-    if report.failed:
-        sys.exit(f"{quantify(len(report.failed), 'populate-zarr job')} failed")
+            raise click.UsageError("zarrs.remote not set in config file")
+        if workers is not None:
+            datasetter.config.workers = workers
+        zarr_root = datasetter.config.zarr_root
+        assert zarr_root is not None
+        if zarrs:
+            diriter = (zarr_root / z for z in zarrs)
+        else:
+            diriter = zarr_root.iterdir()
+        dirs: list[Path] = []
+        for p in diriter:
+            if p.is_dir() and p.name not in (".git", ".datalad"):
+                dirs.append(p)
+            else:
+                log.debug("Skipping non-Zarr node %s", p.name)
+        report = await pool_amap(
+            partial(
+                populate,
+                backup_remote=backup_remote,
+                pathtype="Zarr",
+                jobs=datasetter.config.jobs,
+            ),
+            afilter_installed(dirs),
+            workers=datasetter.config.workers,
+        )
+        if report.failed:
+            sys.exit(f"{quantify(len(report.failed), 'populate-zarr job')} failed")
 
 
 async def populate(dirpath: Path, backup_remote: str, pathtype: str, jobs: int) -> None:
@@ -380,4 +384,4 @@ async def afilter_installed(datasets: list[Path]) -> AsyncIterable[Path]:
 
 
 if __name__ == "__main__":
-    main()
+    main(_anyio_backend="asyncio")

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -21,7 +21,8 @@ from .adataset import AsyncDataset
 from .aioutil import TextProcess, aiter, pool_amap
 from .config import Config
 from .datasetter import DandiDatasetter
-from .util import format_errors, log, pdb_excepthook, quantify
+from .logging import log
+from .util import format_errors, pdb_excepthook, quantify
 
 
 @click.group()

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -16,7 +16,7 @@ from datalad.api import Dataset
 
 from .adataset import AsyncDataset
 from .aioutil import aiter, open_git_annex, pool_amap
-from .config import Config
+from .config import BackupConfig
 from .datasetter import DandiDatasetter
 from .logging import log
 from .util import format_errors, pdb_excepthook, quantify
@@ -63,9 +63,9 @@ async def main(
     config: Optional[Path],
 ) -> None:
     if config is None:
-        cfg = Config()
+        cfg = BackupConfig()
     else:
-        cfg = Config.load_yaml(config)
+        cfg = BackupConfig.load_yaml(config)
     if backup_root is not None:
         cfg.backup_root = backup_root
     if jobs is not None:

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -16,9 +16,10 @@ from dandi.consts import DANDISET_ID_REGEX
 from dandi.dandiapi import DandiAPIClient
 from datalad.api import Dataset
 
+from .aioutil import TextProcess, aiter
 from .config import Config
 from .datasetter import DandiDatasetter
-from .util import TextProcess, aiter, format_errors, log, pdb_excepthook, quantify
+from .util import format_errors, log, pdb_excepthook, quantify
 
 
 @click.group()

--- a/tools/backups2datalad/adandi.py
+++ b/tools/backups2datalad/adandi.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+from typing import Any, AsyncIterator, Optional, Sequence, cast
+
+from anyio.abc import AsyncResource
+from dandi.consts import known_instances
+from dandi.dandiapi import RemoteAsset
+from dandi.dandiapi import RemoteDandiset as SyncRemoteDandiset
+from dandi.dandiapi import Version
+import httpx
+
+from .aioutil import arequest
+from .consts import USER_AGENT
+
+if sys.version_info[:2] >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
+
+@dataclass
+class AsyncDandiClient(AsyncResource):
+    session: httpx.AsyncClient
+
+    @classmethod
+    def for_dandi_instance(cls, instance: str) -> AsyncDandiClient:
+        return cls(
+            session=httpx.AsyncClient(
+                base_url=known_instances[instance].api,
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+            )
+        )
+
+    async def aclose(self) -> None:
+        await self.session.aclose()
+
+    async def get(self, path: str, **kwargs: Any) -> Any:
+        return (await arequest(self.session, "GET", path, **kwargs)).json()
+
+    async def paginate(
+        self,
+        path: str,
+        page_size: Optional[int] = None,
+        params: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator:
+        """
+        Paginate through the resources at the given path: GET the path, yield
+        the values in the ``"results"`` key, and repeat with the URL in the
+        ``"next"`` key until it is ``null``.
+        """
+        if page_size is not None:
+            if params is None:
+                params = {}
+            params["page_size"] = page_size
+        r = await self.get(path, params=params, **kwargs)
+        while True:
+            for item in r["results"]:
+                yield item
+            if r.get("next"):
+                r = await self.get(r["next"])
+            else:
+                break
+
+    async def aget_dandiset(
+        self, dandiset_id: str, version_id: Optional[str] = None
+    ) -> RemoteDandiset:
+        data = await self.get(f"/dandisets/{dandiset_id}/")
+        d = RemoteDandiset.from_data(self, data)
+        if version_id is not None and version_id != d.version_id:
+            if version_id == "draft":
+                dv = d.for_version(d.draft_version)
+            else:
+                dv = d.for_version(await d.aget_version(version_id))
+            assert isinstance(dv, RemoteDandiset)
+            return dv
+        return d
+
+    async def get_dandisets(self) -> AsyncIterator[RemoteDandiset]:
+        # Unlike the synchronous method, this always uses the draft version
+        async with aclosing(self.paginate("/dandisets/")) as ait:
+            async for data in ait:
+                yield RemoteDandiset.from_data(self, data)
+
+    async def get_dandisets_by_ids(
+        self, dandiset_ids: Sequence[str]
+    ) -> AsyncIterator[RemoteDandiset]:
+        for did in dandiset_ids:
+            data = await self.get(f"/dandisets/{did}/")
+            yield RemoteDandiset.from_data(self, data)
+
+
+class RemoteDandiset(SyncRemoteDandiset):
+    def __init__(self, aclient: AsyncDandiClient, **kwargs: Any) -> None:
+        super().__init__(client=None, **kwargs)
+        self.aclient = aclient
+
+    @classmethod
+    def from_data(cls, aclient: AsyncDandiClient, data: dict) -> RemoteDandiset:
+        # Unlike the synchronous method, this always uses the draft version
+        return cls(
+            aclient=aclient,
+            identifier=data["identifier"],
+            version=Version.parse_obj(data["draft_version"]),
+            data=data,
+        )
+
+    def __repr__(self) -> str:
+        return f"<Dandiset {self.identifier}/{self.version_id}>"
+
+    def __str__(self) -> str:
+        return f"Dandiset {self.identifier}/{self.version_id}"
+
+    async def aget_raw_metadata(self) -> dict:
+        return cast(dict, await self.aclient.get(self.version_api_path))
+
+    async def aget_version(self, version_id: str) -> Version:
+        return Version.parse_obj(
+            self.aclient.get(f"/dandisets/{self.identifier}/versions/{version_id}/info")
+        )
+
+    async def aget_versions(self, include_draft: bool = True) -> AsyncIterator[Version]:
+        async with aclosing(self.client.paginate(f"{self.api_path}versions/")) as ait:
+            async for v in ait:
+                if v["identifier"] != "draft" or include_draft:
+                    yield Version.parse_obj(v)
+
+    async def aget_assets(self) -> AsyncIterator[RemoteAsset]:
+        async for item in self.aclient.paginate(
+            f"{self.version_api_path}assets/", params={"order": "created"}
+        ):
+            metadata = await self.aget(f"/assets/{item['asset_id']}/")
+            yield RemoteAsset.from_data(self, item, metadata)

--- a/tools/backups2datalad/adandi.py
+++ b/tools/backups2datalad/adandi.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import sys
-from typing import Any, AsyncIterator, Optional, Sequence, cast
+from time import time
+from typing import Any, AsyncGenerator, Optional, Sequence, cast
 
+import anyio
 from anyio.abc import AsyncResource
 from dandi.consts import known_instances
-from dandi.dandiapi import RemoteAsset
+from dandi.dandiapi import DandiAPIClient, RemoteAsset
 from dandi.dandiapi import RemoteDandiset as SyncRemoteDandiset
 from dandi.dandiapi import Version
 import httpx
 
 from .aioutil import arequest
 from .consts import USER_AGENT
+from .logging import log
 
 if sys.version_info[:2] >= (3, 10):
     from contextlib import aclosing
@@ -25,11 +29,16 @@ class AsyncDandiClient(AsyncResource):
     session: httpx.AsyncClient
 
     @classmethod
-    def for_dandi_instance(cls, instance: str) -> AsyncDandiClient:
+    def for_dandi_instance(
+        cls, instance: str, token: Optional[str] = None
+    ) -> AsyncDandiClient:
+        headers = {"User-Agent": USER_AGENT}
+        if token is not None:
+            headers["Authorization"] = f"token {token}"
         return cls(
             session=httpx.AsyncClient(
                 base_url=known_instances[instance].api,
-                headers={"User-Agent": USER_AGENT},
+                headers=headers,
                 follow_redirects=True,
             )
         )
@@ -40,13 +49,19 @@ class AsyncDandiClient(AsyncResource):
     async def get(self, path: str, **kwargs: Any) -> Any:
         return (await arequest(self.session, "GET", path, **kwargs)).json()
 
+    async def post(self, path: str, **kwargs: Any) -> Any:
+        return (await arequest(self.session, "POST", path, **kwargs)).json()
+
+    async def delete(self, path: str, **kwargs: Any) -> None:
+        await arequest(self.session, "DELETE", path, **kwargs)
+
     async def paginate(
         self,
         path: str,
         page_size: Optional[int] = None,
         params: Optional[dict] = None,
         **kwargs: Any,
-    ) -> AsyncIterator:
+    ) -> AsyncGenerator:
         """
         Paginate through the resources at the given path: GET the path, yield
         the values in the ``"results"`` key, and repeat with the URL in the
@@ -65,21 +80,19 @@ class AsyncDandiClient(AsyncResource):
             else:
                 break
 
-    async def aget_dandiset(
+    async def get_dandiset(
         self, dandiset_id: str, version_id: Optional[str] = None
     ) -> RemoteDandiset:
         data = await self.get(f"/dandisets/{dandiset_id}/")
         d = RemoteDandiset.from_data(self, data)
         if version_id is not None and version_id != d.version_id:
             if version_id == "draft":
-                dv = d.for_version(d.draft_version)
+                return d.for_version(d.draft_version)
             else:
-                dv = d.for_version(await d.aget_version(version_id))
-            assert isinstance(dv, RemoteDandiset)
-            return dv
+                return d.for_version(await d.aget_version(version_id))
         return d
 
-    async def get_dandisets(self) -> AsyncIterator[RemoteDandiset]:
+    async def get_dandisets(self) -> AsyncGenerator[RemoteDandiset, None]:
         # Unlike the synchronous method, this always uses the draft version
         async with aclosing(self.paginate("/dandisets/")) as ait:
             async for data in ait:
@@ -87,15 +100,28 @@ class AsyncDandiClient(AsyncResource):
 
     async def get_dandisets_by_ids(
         self, dandiset_ids: Sequence[str]
-    ) -> AsyncIterator[RemoteDandiset]:
+    ) -> AsyncGenerator[RemoteDandiset, None]:
         for did in dandiset_ids:
             data = await self.get(f"/dandisets/{did}/")
             yield RemoteDandiset.from_data(self, data)
 
+    async def create_dandiset(
+        self, name: str, metadata: dict[str, Any]
+    ) -> RemoteDandiset:
+        return RemoteDandiset.from_data(
+            self,
+            await self.post("/dandisets/", json={"name": name, "metadata": metadata}),
+        )
+
 
 class RemoteDandiset(SyncRemoteDandiset):
     def __init__(self, aclient: AsyncDandiClient, **kwargs: Any) -> None:
-        super().__init__(client=None, **kwargs)
+        # We need to provide a DandiAPIClient so that pydantic doesn't error
+        # when trying to construct asset instances
+        nullclient = DandiAPIClient()
+        # Ensure it doesn't accidentally make any requests:
+        nullclient.session = None
+        super().__init__(client=nullclient, **kwargs)
         self.aclient = aclient
 
     @classmethod
@@ -114,6 +140,14 @@ class RemoteDandiset(SyncRemoteDandiset):
     def __str__(self) -> str:
         return f"Dandiset {self.identifier}/{self.version_id}"
 
+    def for_version(self, v: Version) -> RemoteDandiset:
+        return type(self)(
+            aclient=self.aclient,
+            identifier=self.identifier,
+            version=v,
+            data=self._data,
+        )
+
     async def aget_raw_metadata(self) -> dict:
         return cast(dict, await self.aclient.get(self.version_api_path))
 
@@ -122,15 +156,57 @@ class RemoteDandiset(SyncRemoteDandiset):
             self.aclient.get(f"/dandisets/{self.identifier}/versions/{version_id}/info")
         )
 
-    async def aget_versions(self, include_draft: bool = True) -> AsyncIterator[Version]:
-        async with aclosing(self.client.paginate(f"{self.api_path}versions/")) as ait:
+    async def aget_versions(
+        self, include_draft: bool = True
+    ) -> AsyncGenerator[Version, None]:
+        async with aclosing(self.aclient.paginate(f"{self.api_path}versions/")) as ait:
             async for v in ait:
-                if v["identifier"] != "draft" or include_draft:
+                if v["version"] != "draft" or include_draft:
                     yield Version.parse_obj(v)
 
-    async def aget_assets(self) -> AsyncIterator[RemoteAsset]:
+    async def aget_assets(self) -> AsyncGenerator[RemoteAsset, None]:
         async for item in self.aclient.paginate(
             f"{self.version_api_path}assets/", params={"order": "created"}
         ):
-            metadata = await self.aget(f"/assets/{item['asset_id']}/")
+            metadata = await self.aclient.get(f"/assets/{item['asset_id']}/")
             yield RemoteAsset.from_data(self, item, metadata)
+
+    async def aget_asset_by_path(self, path: str) -> RemoteAsset:
+        async with aclosing(
+            self.aclient.paginate(
+                f"{self.version_api_path}assets/",
+                params={"path": path},
+            )
+        ) as ait:
+            async for item in ait:
+                if item["path"] == path:
+                    metadata = await self.aclient.get(f"/assets/{item['asset_id']}/")
+                    return RemoteAsset.from_data(self, item, metadata)
+        raise ValueError(f"Asset not found: {path}")
+
+    async def await_until_valid(self, max_time: float = 120) -> None:
+        log.debug("Waiting for Dandiset %s to complete validation ...", self.identifier)
+        start = time()
+        while time() - start < max_time:
+            r = await self.aclient.get(f"{self.version_api_path}info/")
+            if r["status"] == "Valid":
+                return
+            await anyio.sleep(0.5)
+        about = {
+            "asset_validation_errors": r.get("asset_validation_errors"),
+            "version_validation_errors": r.get("version_validation_errors"),
+        }
+        raise ValueError(
+            f"Dandiset {self.identifier} is {r['status']}:"
+            f" {json.dumps(about, indent=4)}"
+        )
+
+    async def apublish(self) -> RemoteDandiset:
+        return self.for_version(
+            Version.parse_obj(
+                await self.aclient.post(f"{self.version_api_path}publish/")
+            )
+        )
+
+    async def adelete(self) -> None:
+        await self.aclient.delete(self.api_path)

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -14,7 +14,7 @@ from typing import Any, Optional, Sequence, cast
 import anyio
 from datalad.api import Dataset
 
-from .aioutil import aiter, areadcmd, aruncmd, open_git_annex, stream_null_command
+from .aioutil import areadcmd, aruncmd, open_git_annex, stream_null_command
 from .config import Remote
 from .consts import DEFAULT_BRANCH
 from .logging import log
@@ -172,7 +172,7 @@ class AsyncDataset:
         async with await open_git_annex(
             "find", "--include=*", "--json", use_stdin=False, path=self.pathobj
         ) as p:
-            async for line in aiter(p):
+            async for line in p:
                 data = json.loads(line)
                 path = cast(str, data["file"])
                 filedict[path] = replace(filedict[path], size=int(data["bytesize"]))

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from datetime import datetime
+from enum import Enum
+from functools import partial
+from operator import attrgetter
+from pathlib import Path
+import subprocess
+from typing import Any, AsyncIterator, Optional, Sequence, cast
+
+import anyio
+from anyio.streams.text import TextReceiveStream
+from datalad.api import Dataset
+
+from .aioutil import areadcmd, aruncmd
+from .config import Remote
+from .consts import DEFAULT_BRANCH
+from .util import custom_commit_env, log
+
+
+@dataclass
+class AsyncDataset:
+    ds: Dataset = field(init=False)
+    dirpath: InitVar[str | Path]
+
+    def __post_init__(self, dirpath: str | Path) -> None:
+        self.ds = Dataset(dirpath)
+
+    @property
+    def path(self) -> str:
+        return cast(str, self.ds.path)
+
+    @property
+    def pathobj(self) -> Path:
+        return cast(Path, self.ds.pathobj)
+
+    async def ensure_installed(
+        self,
+        desc: str,
+        commit_date: Optional[datetime] = None,
+        backup_remote: Optional[Remote] = None,
+        backend: str = "SHA256E",
+        cfg_proc: Optional[str] = "text2git",
+    ) -> bool:
+        # Returns True if the dataset was freshly created
+        if self.ds.is_installed():
+            return False
+        log.info("Creating dataset for %s", desc)
+        argv = ["datalad", "-c", f"datalad.repo.backend={backend}", "create"]
+        if cfg_proc is not None:
+            argv.append("-c")
+            argv.append(cfg_proc)
+        argv.append(self.path)
+        await aruncmd(
+            *argv,
+            env={
+                **custom_commit_env(commit_date),
+                "GIT_CONFIG_PARAMETERS": f"'init.defaultBranch={DEFAULT_BRANCH}'",
+            },
+        )
+        if backup_remote is not None:
+            await self.call_annex(
+                "initremote",
+                backup_remote.name,
+                f"type={backup_remote.type}",
+                *[f"{k}={v}" for k, v in backup_remote.options.items()],
+            )
+            await self.call_annex("untrust", backup_remote.name)
+            await self.call_annex(
+                "wanted",
+                backup_remote.name,
+                "(not metadata=distribution-restrictions=*)",
+            )
+        log.debug("Dataset for %s created", desc)
+        return True
+
+    async def is_dirty(self) -> bool:
+        return await anyio.to_thread.run_sync(attrgetter("dirty"), self.ds.repo)
+
+    async def is_unclean(self) -> bool:
+        def _unclean() -> bool:
+            return any(
+                r["state"] != "clean" for r in self.ds.status(result_renderer=None)
+            )
+
+        return await anyio.to_thread.run_sync(_unclean)
+
+    async def get_repo_config(self, key: str) -> Optional[str]:
+        try:
+            return await areadcmd("git", "config", "--get", key, cwd=self.path)
+        except subprocess.CalledProcessError:
+            return None
+
+    async def call_git(self, *args: str | Path, **kwargs: Any) -> None:
+        await aruncmd("git", *args, cwd=self.path, **kwargs)
+
+    async def read_git(self, *args: str | Path, **kwargs: Any) -> str:
+        return await areadcmd("git", *args, cwd=self.path, **kwargs)
+
+    async def call_annex(self, *args: str | Path, **kwargs: Any) -> None:
+        await aruncmd("git-annex", *args, cwd=self.path, **kwargs)
+
+    async def save(
+        self,
+        message: str,
+        path: Sequence[str | Path] = (),
+        commit_date: Optional[datetime] = None,
+    ) -> None:
+        # TODO: Improve
+        await aruncmd(
+            "datalad",
+            "save",
+            "-m",
+            message,
+            *path,
+            cwd=self.path,
+            env=custom_commit_env(commit_date),
+        )
+
+    async def push(self, to: str, jobs: int, data: Optional[str] = None) -> None:
+        # TODO: Improve
+        await anyio.to_thread.run_sync(
+            partial(self.ds.push, to=to, jobs=jobs, data=data)
+        )
+
+    async def gc(self) -> None:
+        try:
+            await self.call_git("gc")
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 128:
+                log.warning("`git gc` in %s exited with code 128", self.path)
+            else:
+                raise
+
+    async def add(self, path: str) -> None:
+        # `path` must be relative to the root of the dataset
+        await self.call_git("add", path)
+
+    async def remove(self, path: str) -> None:
+        # `path` must be relative to the root of the dataset
+        await self.call_git("rm", path)
+
+    async def update(self, how: str, sibling: Optional[str] = None) -> None:
+        await anyio.to_thread.run_sync(
+            partial(self.ds.update, how=how, sibling=sibling)
+        )
+
+    async def aiter_file_stats(self) -> AsyncIterator[FileStat]:
+        async with await anyio.open_process(
+            [
+                "git",
+                "ls-tree",
+                "-r",
+                "--format=%(objecttype):%(objectsize):%(path)",
+                "HEAD",
+            ],
+            cwd=self.path,
+            stderr=None,
+        ) as p:
+            buff = ""
+            assert p.stdout is not None
+            async for text in TextReceiveStream(p.stdout):
+                while True:
+                    try:
+                        i = text.index("\0")
+                    except ValueError:
+                        buff = text
+                        break
+                    else:
+                        yield FileStat.from_entry(buff + text[:i])
+                        buff = ""
+                        text = text[i + 1 :]
+            if buff:
+                yield FileStat.from_entry(buff)
+            ### TODO: Raise an exception if p.returncode is nonzero?
+
+    async def create_github_sibling(
+        self,
+        owner: str,
+        name: str,
+        backup_remote: Optional[Remote],
+        *,
+        existing: str = "skip",
+    ) -> bool:
+        # Returns True iff sibling was created
+        if "github" not in (await self.read_git("remote")).splitlines():
+            log.info("Creating GitHub sibling for %s", name)
+            await anyio.to_thread.run_sync(
+                partial(
+                    self.ds.create_sibling_github,
+                    reponame=name,
+                    existing=existing,
+                    name="github",
+                    access_protocol="https",
+                    github_organization=owner,
+                    publish_depends=backup_remote.name
+                    if backup_remote is not None
+                    else None,
+                )
+            )
+            for key, value in [
+                ("remote.github.pushurl", f"git@github.com:{owner}/{name}.git"),
+                (f"branch.{DEFAULT_BRANCH}.remote", "github"),
+                (f"branch.{DEFAULT_BRANCH}.merge", f"refs/heads/{DEFAULT_BRANCH}"),
+            ]:
+                await self.call_git("config", "--local", "--replace-all", key, value)
+            return True
+        else:
+            log.debug("GitHub remote already exists for %s", name)
+            return False
+
+
+class ObjectType(Enum):
+    COMMIT = "commit"
+    BLOB = "blob"
+    TREE = "tree"
+
+
+@dataclass
+class FileStat:
+    path: str
+    type: ObjectType
+    size: Optional[int]
+
+    @classmethod
+    def from_entry(cls, entry: str) -> FileStat:
+        typename, sizestr, path = entry.split(":", maxsplit=2)
+        return cls(
+            path=path,
+            type=ObjectType(typename),
+            size=None if sizestr == "-" else int(sizestr),
+        )

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -136,7 +136,7 @@ class AsyncDataset:
 
     async def add(self, path: str) -> None:
         # `path` must be relative to the root of the dataset
-        await self.call_git("add", path)
+        await self.call_annex("add", path)
 
     async def remove(self, path: str) -> None:
         # `path` must be relative to the root of the dataset

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -16,7 +16,8 @@ from datalad.api import Dataset
 from .aioutil import areadcmd, aruncmd
 from .config import Remote
 from .consts import DEFAULT_BRANCH
-from .util import custom_commit_env, log
+from .logging import log
+from .util import custom_commit_env
 
 
 @dataclass

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -23,7 +23,8 @@ import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream
 import httpx
 
-from .util import exp_wait, log
+from .logging import log
+from .util import exp_wait
 
 T = TypeVar("T")
 InT = TypeVar("InT")

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -25,6 +25,7 @@ from anyio.streams.memory import MemoryObjectReceiveStream
 from anyio.streams.text import TextReceiveStream
 import httpx
 
+from .consts import DEFAULT_WORKERS
 from .logging import log
 from .util import exp_wait
 
@@ -195,7 +196,7 @@ class PoolReport(Generic[InT, OutT]):
 async def pool_amap(
     func: Callable[[InT], Awaitable[OutT]],
     inputs: AsyncIterable[InT],
-    workers: int = 5,
+    workers: int = DEFAULT_WORKERS,
 ) -> PoolReport[InT, OutT]:
     report: PoolReport[InT, OutT] = PoolReport()
 

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+from typing import AsyncIterable, AsyncIterator, Generic, Optional, TypeVar, cast
+
+import anyio
+import httpx
+
+from .util import exp_wait, log
+
+T = TypeVar("T")
+
+DEEP_DEBUG = 5
+
+
+if sys.version_info[:2] >= (3, 10):
+    # So aiter() can be re-exported without mypy complaining:
+    from builtins import aiter as aiter
+else:
+
+    def aiter(obj: AsyncIterable[T]) -> AsyncIterator[T]:
+        return obj.__aiter__()
+
+
+@dataclass
+class TextProcess(anyio.abc.AsyncResource):
+    p: anyio.abc.Process
+    name: str
+    encoding: str = "utf-8"
+    buff: bytes = b""
+
+    async def aclose(self) -> None:
+        if self.p.stdin is not None:
+            await self.p.stdin.aclose()
+        rc = await self.p.wait()
+        if rc != 0 and self.name != "whereis":
+            log.warning(
+                "git-annex %s command exited with return code %d", self.name, rc
+            )
+
+    async def send(self, s: str) -> None:
+        if self.p.returncode is not None:
+            raise RuntimeError(
+                f"git-annex {self.name} command suddenly exited with return"
+                f" code {self.p.returncode}!"
+            )
+        assert self.p.stdin is not None
+        log.log(DEEP_DEBUG, "Sending to %s command: %r", self.name, s)
+        await self.p.stdin.send(s.encode(self.encoding))
+
+    async def readline(self) -> str:
+        if self.p.returncode is not None:
+            raise RuntimeError(
+                f"git-annex {self.name} command suddenly exited with return"
+                f" code {self.p.returncode}!"
+            )
+        assert self.p.stdout is not None
+        while True:
+            try:
+                i = self.buff.index(b"\n")
+            except ValueError:
+                try:
+                    blob = await self.p.stdout.receive()
+                except anyio.EndOfStream:
+                    # EOF
+                    log.log(DEEP_DEBUG, "%s command reached EOF", self.name)
+                    line = self.buff.decode(self.encoding)
+                    self.buff = b""
+                    log.log(
+                        DEEP_DEBUG, "Decoded line from %s command: %r", self.name, line
+                    )
+                    return line
+                else:
+                    self.buff += blob
+            else:
+                line = self.buff[: i + 1].decode(self.encoding)
+                self.buff = self.buff[i + 1 :]
+                log.log(DEEP_DEBUG, "Decoded line from %s command: %r", self.name, line)
+                return line
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        while True:
+            line = await self.readline()
+            if line == "":
+                break
+            else:
+                yield line
+
+
+async def open_git_annex(
+    _nursery: anyio.abc.TaskGroup, *args: str, path: Optional[Path] = None
+) -> TextProcess:
+    # The `nursery` argument was necessary when using trio 0.20 and may become
+    # necessary in a future version of anyio.
+    log.debug("Running git-annex %s", shlex.join(args))
+    p = await anyio.open_process(
+        ["git-annex", *args],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=path,
+    )
+    return TextProcess(p, name=args[0])
+
+
+async def arequest(client: httpx.AsyncClient, method: str, url: str) -> httpx.Response:
+    waits = exp_wait(attempts=10, base=1.8)
+    while True:
+        try:
+            r = await client.request(method, url, follow_redirects=True)
+            r.raise_for_status()
+        except httpx.HTTPError as e:
+            if isinstance(e, httpx.RequestError) or (
+                isinstance(e, httpx.HTTPStatusError) and e.response.status_code >= 500
+            ):
+                try:
+                    delay = next(waits)
+                except StopIteration:
+                    raise e
+                log.warning(
+                    "Retrying %s request to %s in %f seconds as it raised %s: %s",
+                    method.upper(),
+                    url,
+                    delay,
+                    type(e).__name__,
+                    str(e),
+                )
+                await anyio.sleep(delay)
+                continue
+            else:
+                raise
+        return r
+
+
+@dataclass
+class MiniFuture(Generic[T]):
+    event: anyio.Event = field(default_factory=anyio.Event)
+    value: Optional[T] = None
+
+    def set(self, value: T) -> None:
+        self.value = value
+        self.event.set()
+
+    async def get(self) -> T:
+        await self.event.wait()
+        return cast(T, self.value)

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -114,6 +114,7 @@ async def open_git_annex(*args: str, path: Optional[Path] = None) -> TextProcess
         ["git-annex", *args],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
+        stderr=None,
         cwd=path,
     )
     return TextProcess(p, name=args[0])
@@ -215,6 +216,8 @@ async def aruncmd(
     else:
         attrs = ""
     log.debug("Running: %s%s", shlex.join(argstrs), attrs)
+    kwargs.setdefault("stdout", None)
+    kwargs.setdefault("stderr", None)
     return await anyio.run_process(argstrs, **kwargs)
 
 

--- a/tools/backups2datalad/annex.py
+++ b/tools/backups2datalad/annex.py
@@ -48,8 +48,8 @@ class AsyncAnnex(anyio.abc.AsyncResource):
                     path=self.repo,
                 )
             await self.pfromkey.send(f"{key} {path}\n")
-            ### TODO: Do something if readline() returns "" (signalling EOF)
-            r = json.loads(await self.pfromkey.readline())
+            ### TODO: Do something if receive() returns "" (signalling EOF)
+            r = json.loads(await self.pfromkey.receive())
         if not r["success"]:
             log.error(
                 "`git annex fromkey %s %s` call failed:%s",
@@ -71,8 +71,8 @@ class AsyncAnnex(anyio.abc.AsyncResource):
             await self.pexaminekey.send(
                 f"{self.digest_type}-s{size}--{digest} {filename}\n"
             )
-            ### TODO: Do something if readline() returns "" (signalling EOF)
-            return (await self.pexaminekey.readline()).strip()
+            ### TODO: Do something if receive() returns "" (signalling EOF)
+            return (await self.pexaminekey.receive()).strip()
 
     async def get_key_remotes(self, key: str) -> Optional[list[str]]:
         # Returns None if key is not known to git-annex
@@ -87,8 +87,8 @@ class AsyncAnnex(anyio.abc.AsyncResource):
                     warn_on_fail=False,
                 )
             await self.pwhereis.send(f"{key}\n")
-            ### TODO: Do something if readline() returns "" (signalling EOF)
-            whereis = json.loads(await self.pwhereis.readline())
+            ### TODO: Do something if receive() returns "" (signalling EOF)
+            whereis = json.loads(await self.pwhereis.receive())
         if whereis["success"]:
             return [
                 w["description"].strip("[]")
@@ -108,8 +108,8 @@ class AsyncAnnex(anyio.abc.AsyncResource):
                     path=self.repo,
                 )
             await self.pregisterurl.send(f"{key} {url}\n")
-            ### TODO: Do something if readline() returns "" (signalling EOF)
-            r = json.loads(await self.pregisterurl.readline())
+            ### TODO: Do something if receive() returns "" (signalling EOF)
+            r = json.loads(await self.pregisterurl.receive())
         if not r["success"]:
             log.error(
                 "`git annex registerurl %s %s` call failed:%s",

--- a/tools/backups2datalad/annex.py
+++ b/tools/backups2datalad/annex.py
@@ -7,7 +7,8 @@ from typing import AsyncIterator, Dict, List, Optional
 import anyio
 from anyio.streams.text import TextReceiveStream
 
-from .util import TextProcess, format_errors, log, open_git_annex
+from .aioutil import TextProcess, open_git_annex
+from .util import format_errors, log
 
 
 @dataclass

--- a/tools/backups2datalad/annex.py
+++ b/tools/backups2datalad/annex.py
@@ -10,7 +10,8 @@ import anyio
 from anyio.streams.text import TextReceiveStream
 
 from .aioutil import TextProcess, open_git_annex
-from .util import format_errors, log
+from .logging import log
+from .util import format_errors
 
 
 @dataclass

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -23,22 +23,18 @@ from datalad.api import Dataset, clone
 import httpx
 from identify.identify import tags_from_filename
 
+from .aioutil import MiniFuture, TextProcess, aiter, arequest, open_git_annex
 from .annex import AsyncAnnex
 from .config import Config
 from .consts import ZARR_LIMIT
 from .util import (
     AssetTracker,
-    MiniFuture,
     Report,
-    TextProcess,
-    aiter,
-    arequest,
     custom_commit_date,
     format_errors,
     key2hash,
     log,
     maxdatetime,
-    open_git_annex,
     quantify,
 )
 from .zarr import sync_zarr

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -28,7 +28,7 @@ from .adataset import AsyncDataset
 from .aioutil import MiniFuture, TextProcess, aiter, arequest, open_git_annex
 from .annex import AsyncAnnex
 from .config import Config
-from .consts import ZARR_LIMIT
+from .consts import USER_AGENT, ZARR_LIMIT
 from .util import (
     AssetTracker,
     Report,
@@ -381,9 +381,9 @@ async def async_assets(
                     "--json-progress",
                     "--raw",
                     path=ds.pathobj,
-                ) as p, AsyncAnnex(
-                    ds.pathobj
-                ) as annex, httpx.AsyncClient() as s3client:
+                ) as p, AsyncAnnex(ds.pathobj) as annex, httpx.AsyncClient(
+                    headers={"User-Agent": USER_AGENT}
+                ) as s3client:
                     dm = Downloader(
                         dandiset_id=dandiset.identifier,
                         addurl=p,

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -25,7 +25,7 @@ from identify.identify import tags_from_filename
 
 from .adandi import RemoteDandiset
 from .adataset import AsyncDataset
-from .aioutil import MiniFuture, TextProcess, aiter, arequest, open_git_annex
+from .aioutil import MiniFuture, TextProcess, arequest, open_git_annex
 from .annex import AsyncAnnex
 from .config import BackupConfig
 from .consts import USER_AGENT
@@ -300,7 +300,7 @@ class Downloader:
                 self.log.debug("Done feeding URLs to addurl")
 
     async def read_addurl(self) -> None:
-        async with aclosing(aiter(self.addurl)) as lineiter:  # type: ignore[type-var]
+        async with aclosing(self.addurl) as lineiter:
             async for line in lineiter:
                 data = json.loads(line)
                 if "byte-progress" in data:

--- a/tools/backups2datalad/config.py
+++ b/tools/backups2datalad/config.py
@@ -9,7 +9,7 @@ import anyio
 from dandi.utils import yaml_dump, yaml_load
 from pydantic import BaseModel, Field, root_validator
 
-from .consts import DEFAULT_GIT_ANNEX_JOBS, ZARR_LIMIT
+from .consts import DEFAULT_GIT_ANNEX_JOBS, DEFAULT_WORKERS, ZARR_LIMIT
 
 
 class Remote(BaseModel):
@@ -41,7 +41,7 @@ class BackupConfig(BaseModel):
     # <https://github.com/samuelcolvin/pydantic/issues/2636>
     asset_filter: Optional[Pattern] = None
     jobs: int = DEFAULT_GIT_ANNEX_JOBS
-    workers: int = 5
+    workers: int = DEFAULT_WORKERS
     force: Optional[str] = None
     enable_tags: bool = True
 

--- a/tools/backups2datalad/config.py
+++ b/tools/backups2datalad/config.py
@@ -39,6 +39,7 @@ class Config(BaseModel):
     # <https://github.com/samuelcolvin/pydantic/issues/2636>
     asset_filter: Optional[Pattern] = None
     jobs: int = DEFAULT_GIT_ANNEX_JOBS
+    workers: int = 5
     force: Optional[str] = None
     enable_tags: bool = True
 

--- a/tools/backups2datalad/consts.py
+++ b/tools/backups2datalad/consts.py
@@ -6,6 +6,8 @@ DEFAULT_BRANCH = "draft"
 
 DEFAULT_GIT_ANNEX_JOBS = 10
 
+DEFAULT_WORKERS = 5
+
 # Maximum number of Zarrs to process at once
 ZARR_LIMIT = 32
 

--- a/tools/backups2datalad/consts.py
+++ b/tools/backups2datalad/consts.py
@@ -11,6 +11,8 @@ ZARR_LIMIT = 32
 
 USER_AGENT = (
     "backups2datalad (https://github.com/dandi/dandisets) httpx/{} {}/{}".format(
-        httpx.__version__, platform.python_implementation(), platform.python_version()
+        httpx.__version__,
+        platform.python_implementation(),
+        platform.python_version(),
     )
 )

--- a/tools/backups2datalad/consts.py
+++ b/tools/backups2datalad/consts.py
@@ -1,6 +1,16 @@
+import platform
+
+import httpx
+
 DEFAULT_BRANCH = "draft"
 
 DEFAULT_GIT_ANNEX_JOBS = 10
 
 # Maximum number of Zarrs to process at once
 ZARR_LIMIT = 32
+
+USER_AGENT = (
+    "backups2datalad (https://github.com/dandi/dandisets) httpx/{} {}/{}".format(
+        httpx.__version__, platform.python_implementation(), platform.python_version()
+    )
+)

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -22,7 +22,7 @@ from packaging.version import Version as PkgVersion
 from .adandi import AsyncDandiClient, RemoteDandiset
 from .adataset import AsyncDataset, ObjectType
 from .aioutil import areadcmd, arequest, pool_amap
-from .config import Config
+from .config import BackupConfig
 from .consts import DEFAULT_BRANCH, USER_AGENT
 from .logging import log
 from .syncer import Syncer
@@ -44,7 +44,7 @@ else:
 @dataclass
 class DandiDatasetter(AsyncResource):
     dandi_client: AsyncDandiClient
-    config: Config
+    config: BackupConfig
     gh: Optional[httpx.AsyncClient] = None
 
     async def aclose(self) -> None:

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -29,7 +29,6 @@ from .syncer import Syncer
 from .util import (
     AssetTracker,
     assets_eq,
-    dandi_logging,
     is_meta_file,
     quantify,
     update_dandiset_metadata,
@@ -125,11 +124,10 @@ class DandiDatasetter(AsyncResource):
         syncer = Syncer(
             config=self.config, dandiset=dandiset, ds=ds, tracker=tracker, log=dlog
         )
-        with dandi_logging(ds.pathobj) as logfile:  ### TODO!!!
-            await update_dandiset_metadata(dandiset, ds)
-            await syncer.sync_assets()
-            await syncer.prune_deleted()
-            syncer.dump_asset_metadata()
+        await update_dandiset_metadata(dandiset, ds)
+        await syncer.sync_assets()
+        await syncer.prune_deleted()
+        syncer.dump_asset_metadata()
         assert syncer.report is not None
         dlog.debug("Checking whether repository is dirty ...")
         if await ds.is_unclean():
@@ -143,8 +141,7 @@ class DandiDatasetter(AsyncResource):
         else:
             dlog.debug("Repository is clean")
             if syncer.report.commits == 0:
-                dlog.info("No changes made to repository; deleting logfile")
-                logfile.unlink()
+                dlog.info("No changes made to repository")
         dlog.debug("Running `git gc`")
         await ds.gc()
         dlog.debug("Finished running `git gc`")

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -408,7 +408,7 @@ class DandiDatasetter(AsyncResource):
             await ds.call_git(
                 "tag",
                 "-m",
-                f"Version {dandiset.version_id} of Dandiset" f" {dandiset.identifier}",
+                f"Version {dandiset.version_id} of Dandiset {dandiset.identifier}",
                 dandiset.version_id,
                 env={
                     **os.environ,

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -2,250 +2,253 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from functools import cached_property
 import json
 import logging
 from operator import attrgetter
+import os
 from pathlib import Path
 import re
-import shlex
-import subprocess
-from time import sleep
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
+import sys
+from typing import Any, AsyncIterator, Optional, Sequence
 
+import anyio
+from anyio.abc import AsyncResource
 from dandi.consts import dandiset_metadata_file
-from dandi.dandiapi import DandiAPIClient, RemoteDandiset
-import datalad
-from datalad.api import Dataset
 from ghrepo import GHRepo
-from github import Github
-from github.GithubException import UnknownObjectException
-from github.Repository import Repository
+import httpx
 from humanize import naturalsize
-from morecontext import envset
-from packaging.version import Version
-from urllib3.util.retry import Retry
+from packaging.version import Version as PkgVersion
 
+from .adandi import AsyncDandiClient, RemoteDandiset
+from .adataset import AsyncDataset, ObjectType
+from .aioutil import areadcmd, arequest, pool_amap
 from .config import Config
-from .consts import DEFAULT_BRANCH
+from .consts import DEFAULT_BRANCH, USER_AGENT
 from .syncer import Syncer
 from .util import (
+    AssetTracker,
     assets_eq,
-    create_github_sibling,
-    custom_commit_date,
     dandi_logging,
-    init_dataset,
     is_meta_file,
     log,
     quantify,
-    readcmd,
     update_dandiset_metadata,
 )
 
+if sys.version_info[:2] >= (3, 10):
+    from contextlib import aclosing
+else:
+    from async_generator import aclosing
+
 
 @dataclass
-class DandiDatasetter:
-    dandi_client: DandiAPIClient
+class DandiDatasetter(AsyncResource):
+    dandi_client: AsyncDandiClient
     config: Config
+    gh: Optional[httpx.AsyncClient] = None
 
-    def ensure_superdataset(self) -> Dataset:
-        superds = Dataset(self.config.dandiset_root)
-        if not superds.is_installed():
-            log.info("Creating Datalad superdataset")
-            with envset(
-                "GIT_CONFIG_PARAMETERS", f"'init.defaultBranch={DEFAULT_BRANCH}'"
-            ):
-                superds.create(cfg_proc="text2git")
+    async def aclose(self) -> None:
+        await self.dandi_client.aclose()
+        if self.gh is not None:
+            await self.gh.aclose()
+
+    async def ensure_superdataset(self) -> AsyncDataset:
+        superds = AsyncDataset(self.config.dandiset_root)
+        await superds.ensure_installed("superdataset")
         return superds
 
-    def update_from_backup(
+    async def update_from_backup(
         self,
         dandiset_ids: Sequence[str] = (),
         exclude: Optional[re.Pattern[str]] = None,
     ) -> None:
-        datalad.cfg.set("datalad.repo.backend", "SHA256E", scope="override")
-        superds = self.ensure_superdataset()
-        to_save: List[str] = []
-        ds_stats: List[DandisetStats] = []
-        for d in self.get_dandisets(dandiset_ids, exclude=exclude):
-            dsdir = self.config.dandiset_root / d.identifier
-            ds = self.init_dataset(
-                dsdir, dandiset_id=d.identifier, create_time=d.version.created
-            )
-            changed = self.sync_dataset(d, ds)
-            to_save.append(d.identifier)
-            self.ensure_github_remote(ds, d.identifier)
-            self.tag_releases(d, ds, push=self.config.gh_org is not None)
-            if self.config.gh_org is not None:
-                if changed:
-                    log.info("Pushing to sibling")
-                    ds.push(to="github", jobs=self.config.jobs, data="nothing")
-                ds_stats.append(self.set_dandiset_gh_metadata(d, ds))
+        superds = await self.ensure_superdataset()
+        report = await pool_amap(
+            self.sync_dataset,
+            self.get_dandisets(dandiset_ids, exclude=exclude),
+            workers=self.config.workers,
+        )
+        to_save: list[str] = []
+        ds_stats: list[DandisetStats] = []
+        for d, stats in report.results:
+            to_save.append(d)
+            if self.config.gh_org:
+                assert stats is not None
+                ds_stats.append(stats)
         log.debug("Committing superdataset")
-        superds.save(message="CRON update", path=to_save)
+        await superds.save(message="CRON update", path=to_save)
         log.debug("Superdataset committed")
         if self.config.gh_org is not None and not dandiset_ids and exclude is None:
-            self.set_superds_description(superds, ds_stats)
-
-    def init_dataset(
-        self, dsdir: Path, dandiset_id: str, create_time: datetime
-    ) -> Dataset:
-        ds = Dataset(dsdir)
-        if not ds.is_installed():
-            init_dataset(
-                ds,
-                desc=f"Dandiset {dandiset_id}",
-                commit_date=create_time,
-                backup_remote=self.config.dandisets.remote,
+            await self.set_superds_description(superds, ds_stats)
+        if report.failed:
+            raise RuntimeError(
+                f"Backups for {quantify(len(report.failed), 'Dandiset')} failed"
             )
+
+    async def init_dataset(
+        self, dsdir: Path, dandiset_id: str, create_time: datetime
+    ) -> AsyncDataset:
+        ds = AsyncDataset(dsdir)
+        await ds.ensure_installed(
+            desc=f"Dandiset {dandiset_id}",
+            commit_date=create_time,
+            backup_remote=self.config.dandisets.remote,
+        )
         return ds
 
-    def ensure_github_remote(self, ds: Dataset, dandiset_id: str) -> None:
+    async def ensure_github_remote(self, ds: AsyncDataset, dandiset_id: str) -> None:
         if self.config.gh_org is not None:
-            if create_github_sibling(
-                ds,
+            if await ds.create_github_sibling(
                 owner=self.config.gh_org,
                 name=dandiset_id,
                 backup_remote=self.config.dandisets.remote,
             ):
-                while True:
-                    try:
-                        r = self.get_github_repo(f"{self.config.gh_org}/{dandiset_id}")
-                    except UnknownObjectException:
-                        log.warning(
-                            "GitHub sibling for %s not created yet; sleeping"
-                            " and retrying",
-                            dandiset_id,
-                        )
-                        sleep(5)
-                    else:
-                        break
-                r.edit(homepage=f"https://identifiers.org/DANDI:{dandiset_id}")
+                await self.edit_github_repo(
+                    GHRepo(self.config.gh_org, dandiset_id),
+                    homepage=f"https://identifiers.org/DANDI:{dandiset_id}",
+                )
 
-    def sync_dataset(self, dandiset: RemoteDandiset, ds: Dataset) -> bool:
-        # Returns true if any changes were committed to the repository
+    async def sync_dataset(
+        self, dandiset: RemoteDandiset, ds: Optional[AsyncDataset] = None
+    ) -> Optional[DandisetStats]:
+        if ds is None:
+            ds = await self.init_dataset(
+                self.config.dandiset_root / dandiset.identifier,
+                dandiset_id=dandiset.identifier,
+                create_time=dandiset.version.created,
+            )
         log.info("Syncing Dandiset %s", dandiset.identifier)
-        if ds.repo.dirty:
+        if await ds.is_dirty():
             raise RuntimeError(f"Dirty {dandiset}; clean or save before running")
-        with Syncer(config=self.config, dandiset=dandiset, ds=ds) as syncer:
-            with dandi_logging(ds.pathobj) as logfile:
-                update_dandiset_metadata(dandiset, ds)
-                syncer.sync_assets()
-                syncer.prune_deleted()
-                syncer.dump_asset_metadata()
-            assert syncer.report is not None
-            log.debug("Checking whether repository is dirty ...")
-            if any(r["state"] != "clean" for r in ds.status(result_renderer=None)):
-                log.info("Committing changes")
-                with custom_commit_date(dandiset.version.modified):
-                    ds.save(message=syncer.get_commit_message())
-                log.debug("Commit made")
-                syncer.report.commits += 1
-            else:
-                log.debug("Repository is clean")
-                if syncer.report.commits == 0:
-                    log.info("No changes made to repository; deleting logfile")
-                    logfile.unlink()
-            log.debug("Running `git gc`")
-            try:
-                subprocess.run(["git", "gc"], cwd=ds.path, check=True)
-            except subprocess.CalledProcessError as e:
-                if e.returncode == 128:
-                    log.warning("`git gc` in %s exited with code 128", ds.path)
-                else:
-                    raise
-            log.debug("Finished running `git gc`")
-            return syncer.report.commits > 0
+        tracker = await anyio.to_thread.run_sync(AssetTracker.from_dataset, ds.pathobj)
+        syncer = Syncer(config=self.config, dandiset=dandiset, ds=ds, tracker=tracker)
+        with dandi_logging(ds.pathobj) as logfile:  ### TODO!!!
+            await update_dandiset_metadata(dandiset, ds)
+            await syncer.sync_assets()
+            await syncer.prune_deleted()
+            syncer.dump_asset_metadata()
+        assert syncer.report is not None
+        log.debug("Checking whether repository is dirty ...")
+        if await ds.is_unclean():
+            log.info("Committing changes")
+            await ds.save(
+                message=syncer.get_commit_message(),
+                commit_date=dandiset.version.modified,
+            )
+            log.debug("Commit made")
+            syncer.report.commits += 1
+        else:
+            log.debug("Repository is clean")
+            if syncer.report.commits == 0:
+                log.info("No changes made to repository; deleting logfile")
+                logfile.unlink()
+        log.debug("Running `git gc`")
+        await ds.gc()
+        log.debug("Finished running `git gc`")
+        changed = syncer.report.commits > 0
+        await self.ensure_github_remote(ds, dandiset.identifier)
+        await self.tag_releases(dandiset, ds, push=self.config.gh_org is not None)
+        if self.config.gh_org is not None:
+            if changed:
+                log.info("Pushing to sibling")
+                await ds.push(to="github", jobs=self.config.jobs, data="nothing")
+            return await self.set_dandiset_gh_metadata(dandiset, ds)
+        else:
+            return None
 
-    def get_remote_url(self, ds: Dataset) -> str:
-        upstream = ds.repo.config.get(f"branch.{DEFAULT_BRANCH}.remote")
+    async def get_remote_url(self, ds: AsyncDataset) -> str:
+        upstream = await ds.get_repo_config(f"branch.{DEFAULT_BRANCH}.remote")
         if upstream is None:
             raise ValueError(
                 f"Upstream branch not set for {DEFAULT_BRANCH} in {ds.path}"
             )
-        url = ds.repo.config.get(f"remote.{upstream}.url")
+        url = await ds.get_repo_config(f"remote.{upstream}.url")
         if url is None:
             raise ValueError(f"{upstream!r} remote URL not set for {ds.path}")
-        assert isinstance(url, str)
         return url
 
-    def get_github_repo_for_dataset(self, ds: Dataset) -> Repository:
-        url = self.get_remote_url(ds)
-        r = GHRepo.parse_url(url)
-        return self.get_github_repo(str(r))
+    async def get_ghrepo_for_dataset(self, ds: AsyncDataset) -> GHRepo:
+        url = await self.get_remote_url(ds)
+        return GHRepo.parse_url(url)
 
-    def update_github_metadata(
+    async def update_github_metadata(
         self,
         dandiset_ids: Sequence[str],
         exclude: Optional[re.Pattern[str]],
     ) -> None:
-        ds_stats: List[DandisetStats] = []
-        for d in self.get_dandisets(dandiset_ids, exclude=exclude):
-            ds = Dataset(self.config.dandiset_root / d.identifier)
-            ds_stats.append(self.set_dandiset_gh_metadata(d, ds))
+        ds_stats: list[DandisetStats] = []
+        async for d in self.get_dandisets(dandiset_ids, exclude=exclude):
+            ds = AsyncDataset(self.config.dandiset_root / d.identifier)
+            ds_stats.append(await self.set_dandiset_gh_metadata(d, ds))
         if not dandiset_ids and exclude is None:
-            superds = Dataset(self.config.dandiset_root)
-            self.set_superds_description(superds, ds_stats)
+            superds = AsyncDataset(self.config.dandiset_root)
+            await self.set_superds_description(superds, ds_stats)
 
-    def get_dandisets(
+    async def get_dandisets(
         self, dandiset_ids: Sequence[str], exclude: Optional[re.Pattern[str]]
-    ) -> Iterator[RemoteDandiset]:
+    ) -> AsyncIterator[RemoteDandiset]:
         if dandiset_ids:
-            diter = (
-                self.dandi_client.get_dandiset(did, "draft", lazy=False)
-                for did in dandiset_ids
-            )
+            diter = self.dandi_client.get_dandisets_by_ids(dandiset_ids)
         else:
-            diter = (d.for_version("draft") for d in self.dandi_client.get_dandisets())
-        for d in diter:
-            if exclude is not None and exclude.search(d.identifier):
-                log.debug("Skipping dandiset %s", d.identifier)
-            else:
-                yield d
+            diter = self.dandi_client.get_dandisets()
+        async with aclosing(diter):
+            async for d in diter:
+                if exclude is not None and exclude.search(d.identifier):
+                    log.debug("Skipping dandiset %s", d.identifier)
+                else:
+                    yield d
 
-    def get_dandiset_stats(
-        self, ds: Dataset
-    ) -> Tuple[DandisetStats, Dict[str, DandisetStats]]:
+    async def get_dandiset_stats(
+        self, ds: AsyncDataset
+    ) -> tuple[DandisetStats, dict[str, DandisetStats]]:
         files = 0
         size = 0
-        substats: Dict[str, DandisetStats] = {}
-        for filestat in ds.status(annex="basic", result_renderer=None):
-            path = Path(filestat["path"]).relative_to(ds.pathobj)
-            if not is_meta_file(path.parts[0], dandiset=True):
-                if filestat["type"] == "dataset":
-                    zarr_ds = Dataset(filestat["path"])
-                    zarr_id = Path(self.get_remote_url(zarr_ds)).name
-                    try:
-                        zarr_stat = substats[zarr_id]
-                    except KeyError:
-                        zarr_stat, subsubstats = self.get_dandiset_stats(zarr_ds)
-                        assert not subsubstats
-                        substats[zarr_id] = zarr_stat
-                    files += zarr_stat.files
-                    size += zarr_stat.size
-                else:
-                    files += 1
-                    size += filestat["bytesize"]
+        substats: dict[str, DandisetStats] = {}
+        async with aclosing(ds.aiter_file_stats()) as ait:
+            async for filestat in ait:
+                path = Path(ait.path)
+                if not is_meta_file(path.parts[0], dandiset=True):
+                    if ait.type is ObjectType.COMMIT:
+                        zarr_ds = AsyncDataset(ds.pathobj / path)
+                        zarr_id = Path(await self.get_remote_url(zarr_ds)).name
+                        try:
+                            zarr_stat = substats[zarr_id]
+                        except KeyError:
+                            zarr_stat, subsubstats = await self.get_dandiset_stats(
+                                zarr_ds
+                            )
+                            assert not subsubstats
+                            substats[zarr_id] = zarr_stat
+                        files += zarr_stat.files
+                        size += zarr_stat.size
+                    else:
+                        files += 1
+                        assert filestat.size is not None
+                        size += filestat.size
         return (DandisetStats(files=files, size=size), substats)
 
-    def set_dandiset_gh_metadata(self, d: RemoteDandiset, ds: Dataset) -> DandisetStats:
+    async def set_dandiset_gh_metadata(
+        self, d: RemoteDandiset, ds: AsyncDataset
+    ) -> DandisetStats:
         assert self.config.gh_org is not None
         assert self.config.zarr_gh_org is not None
-        repo = self.get_github_repo(f"{self.config.gh_org}/{d.identifier}")
-        log.info("Setting metadata for %s ...", repo.full_name)
-        stats, zarrstats = self.get_dandiset_stats(ds)
-        repo.edit(
+        stats, zarrstats = await self.get_dandiset_stats(ds)
+        await self.edit_github_repo(
+            GHRepo(self.config.gh_org, d.identifier),
             homepage=f"https://identifiers.org/DANDI:{d.identifier}",
-            description=self.describe_dandiset(d, stats),
+            description=await self.describe_dandiset(d, stats),
         )
         for zarr_id, zarr_stat in zarrstats.items():
-            zarr_repo = self.get_github_repo(f"{self.config.zarr_gh_org}/{zarr_id}")
-            log.info("Setting metadata for %s ...", zarr_repo.full_name)
-            zarr_repo.edit(description=self.describe_zarr(zarr_stat))
+            await self.edit_github_repo(
+                GHRepo(self.config.zarr_gh_org, zarr_id),
+                description=self.describe_zarr(zarr_stat),
+            )
         return stats
 
-    def describe_dandiset(self, dandiset: RemoteDandiset, stats: DandisetStats) -> str:
-        metadata = dandiset.get_raw_metadata()
+    async def describe_dandiset(
+        self, dandiset: RemoteDandiset, stats: DandisetStats
+    ) -> str:
+        metadata = await dandiset.aget_raw_metadata()
         desc = dandiset.version.name
         contact = ", ".join(
             c["name"]
@@ -254,7 +257,9 @@ class DandiDatasetter:
         )
         if contact:
             desc = f"{contact}, {desc}"
-        versions = sum(1 for v in dandiset.get_versions() if v.identifier != "draft")
+        versions = 0
+        async for v in dandiset.aget_versions(include_draft=False):
+            versions += 1
         if versions:
             desc = f"{quantify(versions, 'release')}, {desc}"
         size = naturalsize(stats.size)
@@ -264,34 +269,34 @@ class DandiDatasetter:
         size = naturalsize(stats.size)
         return f"{quantify(stats.files, 'file')}, {size}"
 
-    def set_superds_description(
-        self, superds: Dataset, ds_stats: List[DandisetStats]
+    async def set_superds_description(
+        self, superds: AsyncDataset, ds_stats: list[DandisetStats]
     ) -> None:
         log.info("Setting repository description for superdataset")
-        repo = self.get_github_repo_for_dataset(superds)
+        repo = await self.get_ghrepo_for_dataset(superds)
         total_size = naturalsize(sum(s.size for s in ds_stats))
         desc = (
             f"{quantify(len(ds_stats), 'Dandiset')}, {total_size} total."
             "  DataLad super-dataset of all Dandisets from https://github.com/dandisets"
         )
-        repo.edit(description=desc)
+        await self.edit_github_repo(repo, description=desc)
 
-    def tag_releases(self, dandiset: RemoteDandiset, ds: Dataset, push: bool) -> None:
+    async def tag_releases(
+        self, dandiset: RemoteDandiset, ds: AsyncDataset, push: bool
+    ) -> None:
         if not self.config.enable_tags:
             return
         log.info("Tagging releases for Dandiset %s", dandiset.identifier)
-        versions = [v for v in dandiset.get_versions() if v.identifier != "draft"]
+        versions = [v async for v in dandiset.aget_versions(include_draft=False)]
         for v in versions:
-            if readcmd("git", "tag", "-l", v.identifier, cwd=ds.path):
+            if await ds.read_git("tag", "-l", v.identifier):
                 log.debug("Version %s already tagged", v.identifier)
             else:
                 log.info("Tagging version %s", v.identifier)
-                self.mkrelease(dandiset.for_version(v), ds, push=push)
+                await self.mkrelease(dandiset.for_version(v), ds, push=push)
         if versions:
-            latest = max(map(attrgetter("identifier"), versions), key=Version)
-            description = readcmd(
-                "git", "describe", "--tags", "--long", "--always", cwd=ds.path
-            )
+            latest = max(map(attrgetter("identifier"), versions), key=PkgVersion)
+            description = await ds.read_git("describe", "--tags", "--long", "--always")
             if "-" not in description:
                 # No tags on default branch
                 merge = True
@@ -301,44 +306,33 @@ class DandiDatasetter:
                     description,
                 )
                 assert m, f"Could not parse `git describe` output: {description!r}"
-                merge = Version(latest) > Version(m["tag"])
+                merge = PkgVersion(latest) > PkgVersion(m["tag"])
             if merge:
-                log.debug("Running: git merge -s ours %s", shlex.quote(latest))
-                subprocess.run(
-                    [
-                        "git",
-                        "merge",
-                        "-s",
-                        "ours",
-                        "-m",
-                        f"Merge '{latest}' into drafts branch (no differences"
-                        " in content merged)",
-                        latest,
-                    ],
-                    cwd=ds.path,
-                    check=True,
+                await ds.call_git(
+                    "merge",
+                    "-s",
+                    "ours",
+                    "-m",
+                    f"Merge '{latest}' into drafts branch (no differences in"
+                    " content merged)",
+                    latest,
                 )
             if push:
-                ds.push(to="github", jobs=self.config.jobs, data="nothing")
+                await ds.push(to="github", jobs=self.config.jobs, data="nothing")
 
-    def mkrelease(
+    async def mkrelease(
         self,
         dandiset: RemoteDandiset,
-        ds: Dataset,
+        ds: AsyncDataset,
         push: bool,
         commitish: Optional[str] = None,
     ) -> None:
         # `dandiset` must have its version set to the published version
-        repo: Path = ds.pathobj
-        remote_assets = list(dandiset.get_assets())
+        remote_assets = [asset async for asset in dandiset.aget_assets()]
 
-        def git(*args: str, **kwargs: Any) -> None:
-            log.debug("Running: git %s", " ".join(shlex.quote(str(a)) for a in args))
-            subprocess.run(["git", *args], cwd=repo, check=True, **kwargs)
-
-        def commit_has_assets(commit_hash: str) -> bool:
+        async def commit_has_assets(commit_hash: str) -> bool:
             repo_assets = json.loads(
-                readcmd("git", "show", f"{commit_hash}:.dandi/assets.json", cwd=repo)
+                await ds.read_git("show", f"{commit_hash}:.dandi/assets.json")
             )
             return (not remote_assets and not repo_assets) or (
                 repo_assets
@@ -347,13 +341,15 @@ class DandiDatasetter:
                 and assets_eq(remote_assets, repo_assets)
             )
 
-        candidates: List[str]
+        candidates: list[str]
         if commitish is None:
             candidates = []
             # --before orders by commit date, not author date, so we need to
             # filter commits ourselves.
-            commits = readcmd(
-                "git", "log", r"--grep=\[backups2datalad\]", "--format=%H %aI", cwd=repo
+            commits = (
+                await ds.read_git(
+                    "log", r"--grep=\[backups2datalad\]", "--format=%H %aI"
+                )
             ).splitlines()
             for cmt in commits:
                 chash, _, cdate = cmt.partition(" ")
@@ -366,12 +362,10 @@ class DandiDatasetter:
                 # --reverse is applied after -n 1, so we cannot use it to get
                 # just one commit in chronological order after the first
                 # candidate, so we will get all and take last
-                cmt := readcmd(
-                    "git",
+                cmt := await ds.read_git(
                     "rev-list",
                     r"--grep=\[backups2datalad\]",
                     f"{candidates[0]}..HEAD",
-                    cwd=repo,
                 )
             ) != "":
                 candidates.append(cmt.split()[-1])
@@ -388,11 +382,15 @@ class DandiDatasetter:
                 " updating Dandiset metadata",
                 matching[0],
             )
-            git("checkout", "-b", f"release-{dandiset.version_id}", matching[0])
-            update_dandiset_metadata(dandiset, ds)
+            await ds.call_git(
+                "checkout", "-b", f"release-{dandiset.version_id}", matching[0]
+            )
+            await update_dandiset_metadata(dandiset, ds)
             log.debug("Committing changes")
-            with custom_commit_date(dandiset.version.created):
-                ds.save(message=f"[backups2datalad] {dandiset_metadata_file} updated")
+            await ds.save(
+                message=f"[backups2datalad] {dandiset_metadata_file} updated",
+                commit_date=dandiset.version.created,
+            )
             log.debug("Commit made")
         else:
             log.info(
@@ -400,39 +398,40 @@ class DandiDatasetter:
                 " syncing",
                 dandiset.version_id,
             )
-            git("checkout", "-b", f"release-{dandiset.version_id}", candidates[0])
-            self.sync_dataset(dandiset, ds)
-        with envset("GIT_COMMITTER_NAME", "DANDI User"):
-            with envset("GIT_COMMITTER_EMAIL", "info@dandiarchive.org"):
-                with envset("GIT_COMMITTER_DATE", str(dandiset.version.created)):
-                    git(
-                        "tag",
-                        "-m",
-                        f"Version {dandiset.version_id} of Dandiset"
-                        f" {dandiset.identifier}",
-                        dandiset.version_id,
-                    )
-        git("checkout", DEFAULT_BRANCH)
-        git("branch", "-D", f"release-{dandiset.version_id}")
+            await ds.call_git(
+                "checkout", "-b", f"release-{dandiset.version_id}", candidates[0]
+            )
+            await self.sync_dataset(dandiset, ds)
+            await ds.call_git(
+                "tag",
+                "-m",
+                f"Version {dandiset.version_id} of Dandiset" f" {dandiset.identifier}",
+                dandiset.version_id,
+                env={
+                    **os.environ,
+                    "GIT_COMMITTER_NAME": "DANDI User",
+                    "GIT_COMMITTER_EMAIL": "info@dandiarchive.org",
+                    "GIT_COMMITTER_DATE": str(dandiset.version.created),
+                },
+            )
+        await ds.call_git("checkout", DEFAULT_BRANCH)
+        await ds.call_git("branch", "-D", f"release-{dandiset.version_id}")
         if push:
-            git("push", "github", dandiset.version_id)
+            await ds.call_git("push", "github", dandiset.version_id)
 
-    @cached_property
-    def gh(self) -> Github:
-        token = readcmd("git", "config", "hub.oauthtoken")
-        return Github(
-            token,
-            retry=Retry(
-                total=12,
-                backoff_factor=1.25,
-                status_forcelist=[500, 502, 503, 504],
-            ),
-        )
+    async def edit_github_repo(self, repo: GHRepo, **kwargs: Any) -> None:
+        if self.gh is None:
+            token = await areadcmd("git", "config", "hub.oauthtoken")
+            self.gh = httpx.AsyncClient(
+                headers={"Authorization": f"token {token}", "User-Agent": USER_AGENT},
+                follow_redirects=True,
+            )
+        log.debug("Editing repository %s", repo)
+        # Retry on 404's in case we're calling this right after
+        # create_github_sibling(), when the repo may not yet exist
+        await arequest(self.gh, "PATCH", repo.api_url, json=kwargs, retry_on=[404])
 
-    def get_github_repo(self, repo_fullname: str) -> Repository:
-        return self.gh.get_repo(repo_fullname)
-
-    def debug_logfile(self) -> None:
+    async def debug_logfile(self) -> None:
         """
         Log all log messages at DEBUG or higher to a file without disrupting or
         altering the logging to the screen
@@ -443,7 +442,7 @@ class DandiDatasetter:
         for h in root.handlers:
             h.setLevel(screen_level)
         # Superdataset must exist before creating anything in the directory:
-        self.ensure_superdataset()
+        await self.ensure_superdataset()
         logdir = self.config.dandiset_root / ".git" / "dandi" / "backups2datalad"
         logdir.mkdir(exist_ok=True, parents=True)
         filename = "{:%Y.%m.%d.%H.%M.%SZ}.log".format(datetime.utcnow())

--- a/tools/backups2datalad/logging.py
+++ b/tools/backups2datalad/logging.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import logging
+from typing import Any, Optional
+
+
+@dataclass
+class PrefixedLogger:
+    logger: logging.Logger
+    prefix: Optional[str] = None
+
+    def setLevel(self, level: int) -> None:
+        self.logger.setLevel(level)
+
+    def log(self, level: int, msg: str, *args: Any, **kwargs: Any) -> None:
+        if self.prefix:
+            msg = f"%s: {msg}"
+            args = (self.prefix, *args)
+        self.logger.log(level, msg, *args, **kwargs)
+
+    def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self.log(logging.DEBUG, msg, *args, **kwargs)
+
+    def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self.log(logging.INFO, msg, *args, **kwargs)
+
+    def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self.log(logging.WARNING, msg, *args, **kwargs)
+
+    def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self.log(logging.ERROR, msg, *args, **kwargs)
+
+    def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self.log(logging.CRITICAL, msg, *args, **kwargs)
+
+    def exception(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        kwargs["exc_info"] = True
+        self.log(logging.ERROR, msg, *args, **kwargs)
+
+    def sublogger(self, prefix: str) -> PrefixedLogger:
+        if self.prefix is None:
+            p2 = prefix
+        else:
+            p2 = f"{self.prefix}: {prefix}"
+        return replace(self, prefix=p2)
+
+
+log = PrefixedLogger(logging.getLogger("backups2datalad"))

--- a/tools/backups2datalad/logging.py
+++ b/tools/backups2datalad/logging.py
@@ -13,30 +13,32 @@ class PrefixedLogger:
     def setLevel(self, level: int) -> None:
         self.logger.setLevel(level)
 
-    def log(self, level: int, msg: str, *args: Any, **kwargs: Any) -> None:
+    def log(
+        self, level: int, msg: str, *args: Any, stacklevel: int = 2, **kwargs: Any
+    ) -> None:
         if self.prefix:
             msg = f"%s: {msg}"
             args = (self.prefix, *args)
-        self.logger.log(level, msg, *args, **kwargs)
+        self.logger.log(level, msg, *args, stacklevel=stacklevel, **kwargs)
 
     def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self.log(logging.DEBUG, msg, *args, **kwargs)
+        self.log(logging.DEBUG, msg, *args, stacklevel=3, **kwargs)
 
     def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self.log(logging.INFO, msg, *args, **kwargs)
+        self.log(logging.INFO, msg, *args, stacklevel=3, **kwargs)
 
     def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self.log(logging.WARNING, msg, *args, **kwargs)
+        self.log(logging.WARNING, msg, *args, stacklevel=3, **kwargs)
 
     def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self.log(logging.ERROR, msg, *args, **kwargs)
+        self.log(logging.ERROR, msg, *args, stacklevel=3, **kwargs)
 
     def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self.log(logging.CRITICAL, msg, *args, **kwargs)
+        self.log(logging.CRITICAL, msg, *args, stacklevel=3, **kwargs)
 
     def exception(self, msg: str, *args: Any, **kwargs: Any) -> None:
         kwargs["exc_info"] = True
-        self.log(logging.ERROR, msg, *args, **kwargs)
+        self.log(logging.ERROR, msg, *args, stacklevel=3, **kwargs)
 
     def sublogger(self, prefix: str) -> PrefixedLogger:
         if self.prefix is None:

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from dandi.dandiapi import RemoteDandiset
 
-from .adatalad import AsyncDataset
+from .adataset import AsyncDataset
 from .asyncer import async_assets
 from .config import BackupConfig
 from .logging import PrefixedLogger

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -7,14 +7,14 @@ from dandi.dandiapi import RemoteDandiset
 
 from .adatalad import AsyncDataset
 from .asyncer import async_assets
-from .config import Config
+from .config import BackupConfig
 from .logging import PrefixedLogger
 from .util import AssetTracker, Report, quantify
 
 
 @dataclass
 class Syncer:
-    config: Config
+    config: BackupConfig
     dandiset: RemoteDandiset
     ds: AsyncDataset
     tracker: AssetTracker

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -20,8 +20,7 @@ from datalad.api import Dataset
 from datalad.support.json_py import dump
 
 from .config import Config
-
-log = logging.getLogger("backups2datalad")
+from .logging import log
 
 
 @dataclass

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from collections import deque
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 import json
-import logging
 import os
 from pathlib import Path
 import sys
@@ -165,29 +163,6 @@ def dataset_files(dspath: Path) -> Iterator[str]:
                 yield str(p.relative_to(dspath))
             else:
                 files.extend(p.iterdir())
-
-
-@contextmanager
-def dandi_logging(dandiset_path: Path) -> Iterator[Path]:
-    logdir = dandiset_path / ".git" / "dandi" / "logs"
-    logdir.mkdir(exist_ok=True, parents=True)
-    filename = "sync-{:%Y%m%d%H%M%SZ}-{}.log".format(datetime.utcnow(), os.getpid())
-    logfile = logdir / filename
-    handler = logging.FileHandler(logfile, encoding="utf-8")
-    fmter = logging.Formatter(
-        fmt="%(asctime)s [%(levelname)-8s] %(name)s %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S%z",
-    )
-    handler.setFormatter(fmter)
-    root = logging.getLogger()
-    root.addHandler(handler)
-    try:
-        yield logfile
-    except Exception:
-        log.exception("Operation failed with exception:")
-        raise
-    finally:
-        root.removeHandler(handler)
 
 
 def is_interactive() -> bool:

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -19,7 +19,7 @@ from dandi.dandiset import APIDandiset
 from datalad.api import Dataset
 from datalad.support.json_py import dump
 
-from .config import Config
+from .config import BackupConfig
 from .logging import log
 
 
@@ -124,7 +124,7 @@ class AssetTracker:
     def mark_future(self, asset: RemoteAsset) -> None:
         self.future_assets.add(asset.path)
 
-    def get_deleted(self, config: Config) -> Iterator[str]:
+    def get_deleted(self, config: BackupConfig) -> Iterator[str]:
         """
         Yields paths of deleted assets and removes their metadata from
         `asset_metadata`

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -14,52 +14,20 @@ import sys
 import textwrap
 import threading
 from types import TracebackType
-from typing import (
-    Any,
-    AsyncIterable,
-    AsyncIterator,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Iterator, List, Optional, Set, Type, Union, cast
 
-import anyio
 from dandi.consts import dandiset_metadata_file
 from dandi.dandiapi import RemoteAsset, RemoteDandiset
 from dandi.dandiset import APIDandiset
 import datalad
 from datalad.api import Dataset
 from datalad.support.json_py import dump
-import httpx
 from morecontext import envset
 
 from .config import Config, Remote
 from .consts import DEFAULT_BRANCH
 
 log = logging.getLogger("backups2datalad")
-
-T = TypeVar("T")
-
-if sys.version_info[:2] >= (3, 10):
-    # So aiter() can be re-exported without mypy complaining:
-    from builtins import aiter as aiter
-else:
-
-    def aiter(obj: AsyncIterable[T]) -> AsyncIterator[T]:
-        return obj.__aiter__()
-
-    async def anext(obj: AsyncIterator[T]) -> T:
-        return await obj.__anext__()
-
-
-DEEP_DEBUG = 5
 
 
 @dataclass
@@ -111,71 +79,6 @@ class Report:
             raise RuntimeError(
                 f"Errors occurred while downloading: {'; '.join(errors)}"
             )
-
-
-@dataclass
-class TextProcess(anyio.abc.AsyncResource):
-    p: anyio.abc.Process
-    name: str
-    encoding: str = "utf-8"
-    buff: bytes = b""
-
-    async def aclose(self) -> None:
-        if self.p.stdin is not None:
-            await self.p.stdin.aclose()
-        rc = await self.p.wait()
-        if rc != 0 and self.name != "whereis":
-            log.warning(
-                "git-annex %s command exited with return code %d", self.name, rc
-            )
-
-    async def send(self, s: str) -> None:
-        if self.p.returncode is not None:
-            raise RuntimeError(
-                f"git-annex {self.name} command suddenly exited with return"
-                f" code {self.p.returncode}!"
-            )
-        assert self.p.stdin is not None
-        log.log(DEEP_DEBUG, "Sending to %s command: %r", self.name, s)
-        await self.p.stdin.send(s.encode(self.encoding))
-
-    async def readline(self) -> str:
-        if self.p.returncode is not None:
-            raise RuntimeError(
-                f"git-annex {self.name} command suddenly exited with return"
-                f" code {self.p.returncode}!"
-            )
-        assert self.p.stdout is not None
-        while True:
-            try:
-                i = self.buff.index(b"\n")
-            except ValueError:
-                try:
-                    blob = await self.p.stdout.receive()
-                except anyio.EndOfStream:
-                    # EOF
-                    log.log(DEEP_DEBUG, "%s command reached EOF", self.name)
-                    line = self.buff.decode(self.encoding)
-                    self.buff = b""
-                    log.log(
-                        DEEP_DEBUG, "Decoded line from %s command: %r", self.name, line
-                    )
-                    return line
-                else:
-                    self.buff += blob
-            else:
-                line = self.buff[: i + 1].decode(self.encoding)
-                self.buff = self.buff[i + 1 :]
-                log.log(DEEP_DEBUG, "Decoded line from %s command: %r", self.name, line)
-                return line
-
-    async def __aiter__(self) -> AsyncIterator[str]:
-        while True:
-            line = await self.readline()
-            if line == "":
-                break
-            else:
-                yield line
 
 
 @dataclass
@@ -356,21 +259,6 @@ def key2hash(key: str) -> str:
     return key.split("-")[-1].partition(".")[0]
 
 
-async def open_git_annex(
-    _nursery: anyio.abc.TaskGroup, *args: str, path: Optional[Path] = None
-) -> TextProcess:
-    # The `nursery` argument was necessary when using trio 0.20 and may become
-    # necessary in a future version of anyio.
-    log.debug("Running git-annex %s", shlex.join(args))
-    p = await anyio.open_process(
-        ["git-annex", *args],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        cwd=path,
-    )
-    return TextProcess(p, name=args[0])
-
-
 def format_errors(messages: List[str]) -> str:
     if not messages:
         return " <no error message>"
@@ -399,35 +287,6 @@ def exp_wait(
     while attempts is None or n < attempts:
         yield base**n * multiplier
         n += 1
-
-
-async def arequest(client: httpx.AsyncClient, method: str, url: str) -> httpx.Response:
-    waits = exp_wait(attempts=10, base=1.8)
-    while True:
-        try:
-            r = await client.request(method, url, follow_redirects=True)
-            r.raise_for_status()
-        except httpx.HTTPError as e:
-            if isinstance(e, httpx.RequestError) or (
-                isinstance(e, httpx.HTTPStatusError) and e.response.status_code >= 500
-            ):
-                try:
-                    delay = next(waits)
-                except StopIteration:
-                    raise e
-                log.warning(
-                    "Retrying %s request to %s in %f seconds as it raised %s: %s",
-                    method.upper(),
-                    url,
-                    delay,
-                    type(e).__name__,
-                    str(e),
-                )
-                await anyio.sleep(delay)
-                continue
-            else:
-                raise
-        return r
 
 
 def init_dataset(
@@ -497,20 +356,6 @@ def create_github_sibling(
     else:
         log.debug("GitHub remote already exists for %s", name)
         return False
-
-
-@dataclass
-class MiniFuture(Generic[T]):
-    event: anyio.Event = field(default_factory=anyio.Event)
-    value: Optional[T] = None
-
-    def set(self, value: T) -> None:
-        self.value = value
-        self.event.set()
-
-    async def get(self) -> T:
-        await self.event.wait()
-        return cast(T, self.value)
 
 
 def maxdatetime(state: Optional[datetime], candidate: datetime) -> datetime:

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -8,24 +8,18 @@ import json
 import logging
 import os
 from pathlib import Path
-import shlex
-import subprocess
 import sys
 import textwrap
-import threading
 from types import TracebackType
-from typing import Any, Dict, Iterator, List, Optional, Set, Type, Union, cast
+from typing import Any, Iterator, Optional, Type
 
 from dandi.consts import dandiset_metadata_file
 from dandi.dandiapi import RemoteAsset, RemoteDandiset
 from dandi.dandiset import APIDandiset
-import datalad
 from datalad.api import Dataset
 from datalad.support.json_py import dump
-from morecontext import envset
 
-from .config import Config, Remote
-from .consts import DEFAULT_BRANCH
+from .config import Config
 
 log = logging.getLogger("backups2datalad")
 
@@ -62,7 +56,7 @@ class Report:
         return f"[backups2datalad] {', '.join(msgparts)}"
 
     def check(self) -> None:
-        errors: List[str] = []
+        errors: list[str] = []
         if self.failed:
             errors.append(f"{quantify(self.failed, 'asset')} failed to download")
         if self.hash_mismatches:
@@ -87,23 +81,23 @@ class AssetTracker:
     filepath: Path
     #: Paths of files found when the syncing started, minus the paths for any
     #: assets downloaded during syncing
-    local_assets: Set[str]
+    local_assets: set[str]
     #: Metadata for assets currently being downloaded, as a mapping from asset
     #: paths to metadata
-    in_progress: Dict[str, dict] = field(init=False, default_factory=dict)
+    in_progress: dict[str, dict] = field(init=False, default_factory=dict)
     #: Asset metadata from previous sync, plus metadata for any assets
     #: completely downloaded during the sync, as a mapping from asset paths to
     #: metadata
-    asset_metadata: Dict[str, dict]
+    asset_metadata: dict[str, dict]
     #: Paths of assets that are not being downloaded this run due to a lack of
     #: SHA256 digests
-    future_assets: Set[str] = field(init=False, default_factory=set)
+    future_assets: set[str] = field(init=False, default_factory=set)
 
     @classmethod
     def from_dataset(cls, dspath: Path) -> AssetTracker:
         filepath = dspath / ".dandi" / "assets.json"
         local_assets = set(dataset_files(dspath))
-        asset_metadata: Dict[str, dict] = {}
+        asset_metadata: dict[str, dict] = {}
         try:
             with filepath.open() as fp:
                 for md in json.load(fp):
@@ -150,21 +144,13 @@ class AssetTracker:
         return len(self.future_assets)
 
 
-@contextmanager
-def custom_commit_date(
-    dt: Optional[datetime],
-    lock: threading.Lock = threading.Lock(),  # noqa: B008
-) -> Iterator[None]:
+def custom_commit_env(dt: Optional[datetime]) -> dict[str, str]:
+    env = os.environ.copy()
     if dt is not None:
-        with lock:
-            # Lock in order to avoid issues from multiple
-            # custom_commit_date()'s being in scope at once
-            with envset("GIT_AUTHOR_NAME", "DANDI User"):
-                with envset("GIT_AUTHOR_EMAIL", "info@dandiarchive.org"):
-                    with envset("GIT_AUTHOR_DATE", str(dt)):
-                        yield
-    else:
-        yield
+        env["GIT_AUTHOR_NAME"] = "DANDI User"
+        env["GIT_AUTHOR_EMAIL"] = "info@dandiarchive.org"
+        env["GIT_AUTHOR_DATE"] = str(dt)
+    return env
 
 
 def dataset_files(dspath: Path) -> Iterator[str]:
@@ -223,27 +209,22 @@ def pdb_excepthook(
         pdb.post_mortem(tb)
 
 
-def asset2dict(asset: RemoteAsset) -> Dict[str, Any]:
+def asset2dict(asset: RemoteAsset) -> dict[str, Any]:
     return {**asset.json_dict(), "metadata": asset.get_raw_metadata()}
 
 
-def assets_eq(remote_assets: List[RemoteAsset], local_assets: List[dict]) -> bool:
+def assets_eq(remote_assets: list[RemoteAsset], local_assets: list[dict]) -> bool:
     return {a.identifier: asset2dict(a) for a in remote_assets} == {
         a["asset_id"]: a for a in local_assets
     }
 
 
-def readcmd(*args: Union[str, Path], **kwargs: Any) -> str:
-    log.debug("Running: %s", shlex.join(map(str, args)))
-    return cast(str, subprocess.check_output(args, text=True, **kwargs)).strip()
-
-
-def update_dandiset_metadata(dandiset: RemoteDandiset, ds: Dataset) -> None:
+async def update_dandiset_metadata(dandiset: RemoteDandiset, ds: Dataset) -> None:
     log.info("Updating metadata file")
     (ds.pathobj / dandiset_metadata_file).unlink(missing_ok=True)
-    metadata = dandiset.get_raw_metadata()
+    metadata = await dandiset.aget_raw_metadata()
     APIDandiset(ds.pathobj, allow_empty=True).update_metadata(metadata)
-    ds.repo.add([dandiset_metadata_file])
+    await ds.add(dandiset_metadata_file)
 
 
 def quantify(qty: int, singular: str, plural: Optional[str] = None) -> str:
@@ -259,7 +240,7 @@ def key2hash(key: str) -> str:
     return key.split("-")[-1].partition(".")[0]
 
 
-def format_errors(messages: List[str]) -> str:
+def format_errors(messages: list[str]) -> str:
     if not messages:
         return " <no error message>"
     elif len(messages) == 1:
@@ -287,75 +268,6 @@ def exp_wait(
     while attempts is None or n < attempts:
         yield base**n * multiplier
         n += 1
-
-
-def init_dataset(
-    ds: Dataset,
-    desc: str,
-    commit_date: datetime,
-    backup_remote: Optional[Remote] = None,
-    backend: str = "SHA256E",
-    cfg_proc: Optional[str] = "text2git",
-) -> None:
-    log.info("Creating dataset for %s", desc)
-    try:
-        datalad.cfg.set("datalad.repo.backend", backend, scope="override")
-        with custom_commit_date(commit_date):
-            with envset(
-                "GIT_CONFIG_PARAMETERS", f"'init.defaultBranch={DEFAULT_BRANCH}'"
-            ):
-                ds.create(cfg_proc=cfg_proc)
-    finally:
-        datalad.cfg.unset("datalad.repo.backend", scope="override")
-    if backup_remote is not None:
-        ds.repo.init_remote(
-            backup_remote.name,
-            [f"type={backup_remote.type}"]
-            + [f"{k}={v}" for k, v in backup_remote.options.items()],
-        )
-        ds.repo.call_annex(["untrust", backup_remote.name])
-        ds.repo.set_preferred_content(
-            "wanted",
-            "(not metadata=distribution-restrictions=*)",
-            remote=backup_remote.name,
-        )
-    log.debug("Dataset for %s created", desc)
-
-
-def create_github_sibling(
-    ds: Dataset,
-    owner: str,
-    name: str,
-    backup_remote: Optional[Remote],
-    *,
-    existing: str = "skip",
-) -> bool:
-    # Returns True iff sibling was created
-    if "github" not in ds.repo.get_remotes():
-        log.info("Creating GitHub sibling for %s", name)
-        ds.create_sibling_github(
-            reponame=name,
-            existing=existing,
-            name="github",
-            access_protocol="https",
-            github_organization=owner,
-            publish_depends=backup_remote.name if backup_remote is not None else None,
-        )
-        ds.config.set(
-            "remote.github.pushurl",
-            f"git@github.com:{owner}/{name}.git",
-            scope="local",
-        )
-        ds.config.set(f"branch.{DEFAULT_BRANCH}.remote", "github", scope="local")
-        ds.config.set(
-            f"branch.{DEFAULT_BRANCH}.merge",
-            f"refs/heads/{DEFAULT_BRANCH}",
-            scope="local",
-        )
-        return True
-    else:
-        log.debug("GitHub remote already exists for %s", name)
-        return False
 
 
 def maxdatetime(state: Optional[datetime], candidate: datetime) -> datetime:

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -18,10 +18,10 @@ from dandi.dandiapi import RemoteZarrAsset
 from datalad.api import Dataset
 from pydantic import BaseModel
 
+from .aioutil import MiniFuture
 from .annex import AsyncAnnex
 from .config import Config, ResourceConfig
 from .util import (
-    MiniFuture,
     create_github_sibling,
     custom_commit_date,
     init_dataset,

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import os
 from pathlib import Path
 import sys
-from typing import TYPE_CHECKING, AsyncIterator, Iterator, Optional, cast
+from typing import TYPE_CHECKING, AsyncGenerator, Iterator, Optional, cast
 from urllib.parse import quote
 
 from aiobotocore.session import get_session
@@ -307,14 +307,16 @@ class ZarrSyncer:
                 d = d.parent
         self.log.info("finished deleting extra files")
 
-    async def aiter_objects(self, client: S3Client) -> AsyncIterator[dict]:
+    async def aiter_objects(self, client: S3Client) -> AsyncGenerator[dict, None]:
         async for page in client.get_paginator("list_objects_v2").paginate(
             Bucket=self.s3bucket, Prefix=self.s3prefix
         ):
             for obj in page.get("Contents", []):
                 yield cast(dict, obj)
 
-    async def aiter_file_entries(self, client: S3Client) -> AsyncIterator[ZarrEntry]:
+    async def aiter_file_entries(
+        self, client: S3Client
+    ) -> AsyncGenerator[ZarrEntry, None]:
         leadlen = len(self.s3prefix)
         async for page in client.get_paginator("list_object_versions").paginate(
             Bucket=self.s3bucket, Prefix=self.s3prefix

--- a/tools/noxfile.py
+++ b/tools/noxfile.py
@@ -8,7 +8,10 @@ nox.options.stop_on_first_error = True
 def typing(session):
     session.install("-r", "backups2datalad.req.txt")
     session.install("-r", "get-upload-stats.req.txt")
-    session.install("mypy", "types-aiobotocore[s3]", "types-python-dateutil")
+    # trio-typing contains the stubs for async_generator
+    session.install(
+        "mypy", "trio-typing", "types-aiobotocore[s3]", "types-python-dateutil"
+    )
     session.run(
         "mypy", "backups2datalad", "test_backups2datalad", "get-upload-stats.py"
     )

--- a/tools/test_backups2datalad/test_util.py
+++ b/tools/test_backups2datalad/test_util.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 import subprocess
-from typing import Any, cast
+from typing import Any, List, cast
 
 from backups2datalad.util import is_meta_file
 
@@ -90,8 +90,9 @@ class GitRepo:
         }
 
     def get_assets_json(self, commitish: str) -> list[dict]:
+        # We need to use typing.List here for Python 3.8 compatibility
         return cast(
-            list[dict], json.loads(self.get_blob(commitish, ".dandi/assets.json"))
+            List[dict], json.loads(self.get_blob(commitish, ".dandi/assets.json"))
         )
 
     def get_commit_count(self) -> int:

--- a/tools/test_backups2datalad/test_util.py
+++ b/tools/test_backups2datalad/test_util.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import json
 from pathlib import Path
 import subprocess
-from typing import Any, Dict, List, Set, Union, cast
+from typing import Any, cast
 
 from backups2datalad.util import is_meta_file
 
@@ -11,12 +13,10 @@ from backups2datalad.util import is_meta_file
 class GitRepo:
     path: Path
 
-    def runcmd(
-        self, *args: Union[str, Path], **kwargs: Any
-    ) -> subprocess.CompletedProcess:
+    def runcmd(self, *args: str | Path, **kwargs: Any) -> subprocess.CompletedProcess:
         return subprocess.run(["git", *args], cwd=self.path, **kwargs)
 
-    def readcmd(self, *args: Union[str, Path]) -> str:
+    def readcmd(self, *args: str | Path) -> str:
         r = self.runcmd(*args, stdout=subprocess.PIPE, text=True, check=True)
         assert isinstance(r.stdout, str)
         return r.stdout.strip()
@@ -62,25 +62,25 @@ class GitRepo:
     def get_blob(self, treeish: str, path: str) -> str:
         return self.readcmd("show", f"{treeish}:{path}")
 
-    def get_tags(self) -> List[str]:
+    def get_tags(self) -> list[str]:
         return self.readcmd("tag", "-l", "--sort=creatordate").splitlines()
 
-    def get_diff_tree(self, commitish: str) -> Dict[str, str]:
+    def get_diff_tree(self, commitish: str) -> dict[str, str]:
         stat = self.readcmd(
             "diff-tree", "--no-commit-id", "--name-status", "-r", commitish
         )
-        status: Dict[str, str] = {}
+        status: dict[str, str] = {}
         for line in stat.splitlines():
             sym, _, path = line.partition("\t")
             status[path] = sym
         return status
 
-    def get_backup_commits(self) -> List[str]:
+    def get_backup_commits(self) -> list[str]:
         return self.readcmd(
             "rev-list", "--tags", r"--grep=\[backups2datalad\]", "HEAD"
         ).splitlines()
 
-    def get_asset_files(self, commitish: str) -> Set[str]:
+    def get_asset_files(self, commitish: str) -> set[str]:
         return {
             fname
             for fname in self.readcmd(
@@ -89,9 +89,9 @@ class GitRepo:
             if not is_meta_file(fname, dandiset=True)
         }
 
-    def get_assets_json(self, commitish: str) -> List[dict]:
+    def get_assets_json(self, commitish: str) -> list[dict]:
         return cast(
-            List[dict], json.loads(self.get_blob(commitish, ".dandi/assets.json"))
+            list[dict], json.loads(self.get_blob(commitish, ".dandi/assets.json"))
         )
 
     def get_commit_count(self) -> int:


### PR DESCRIPTION
Closes #173.

This adds a `-w`/`--workers` option to the `update-from-backup`, `populate`, and `populate-zarrs` commands; the option can also be set via the config file.