### PR TITLE
Fix 000251 URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -684,7 +684,7 @@
 	datalad-id = 19f4b719-5a6c-40cf-9600-56ec04d563b2
 [submodule "000251"]
 	path = 000251
-	url = ./000251
+	url = https://github.com/dandisets/000251.git
 	datalad-id = 7384af99-e778-4007-b349-8bbcefee3a7c
 [submodule "000252"]
 	path = 000252


### PR DESCRIPTION
The URL for the 000251 submodule was set to a local path for some reason.  This PR corrects it to point to the GitHub repository.