### PR TITLE
Avoid opening an editor when doing `git pull`

### DIFF
--- a/tools/backups2datalad-cron
+++ b/tools/backups2datalad-cron
@@ -10,7 +10,7 @@ eval python -m tools.backups2datalad \
    -e '000108$' \
    "$*" 2>&1 | grep -v 'nothing to save, working tree clean'
 
-git pull
+git pull --commit --no-edit
 datalad push -J 5
 
 python -m tools.backups2datalad \
@@ -19,7 +19,7 @@ python -m tools.backups2datalad \
    --config tools/backups2datalad.cfg.yaml \
    populate "$@"
 
-git pull
+git pull --commit --no-edit
 datalad push -J 5
 
 python -m tools.backups2datalad \
@@ -28,7 +28,7 @@ python -m tools.backups2datalad \
    --config tools/backups2datalad.cfg.yaml \
    populate-zarrs
 
-git pull  # so we possibly merge changes on the server
+git pull --commit --no-edit  # so we possibly merge changes on the server
 datalad push -J 5
 ) 2>|.git/tmp/stderr
 

--- a/tools/backups2datalad-update-cron
+++ b/tools/backups2datalad-update-cron
@@ -12,7 +12,7 @@ eval python -m tools.backups2datalad \
    -e '000108$' \
    "$*" 2>&1 | grep -v 'nothing to save, working tree clean'
 
-git pull
+git pull --commit --no-edit
 datalad push -J 5
 ) 2>|.git/tmp/stderr-2
 


### PR DESCRIPTION
Several times now, I have found the backup script stalled because a `git pull` command opened an editor for entering a commit message for a merge commit.  This PR should hopefully cause such merges to go through automatically.