### PR TITLE
Add `backup-zarrs` subcommand

### DIFF
--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -138,6 +138,32 @@ async def update_from_backup(
 
 @main.command()
 @click.option(
+    "-P",
+    "--partial-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory in which to store in-progress Zarr backups",
+)
+@click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
+@click.argument("dandiset")
+@click.pass_obj
+async def backup_zarrs(
+    datasetter: DandiDatasetter,
+    dandiset: str,
+    workers: Optional[int],
+    partial_dir: Optional[Path],
+) -> None:
+    async with datasetter:
+        if datasetter.config.zarrs is None:
+            raise click.UsageError("Zarr backups not configured in config file")
+        if workers is not None:
+            datasetter.config.workers = workers
+        if partial_dir is None:
+            partial_dir = datasetter.config.backup_root / "partial-zarrs"
+        await datasetter.backup_zarrs(dandiset, partial_dir)
+
+
+@main.command()
+@click.option(
     "-e",
     "--exclude",
     help="Skip dandisets matching the given regex",

--- a/tools/backups2datalad/adandi.py
+++ b/tools/backups2datalad/adandi.py
@@ -11,7 +11,7 @@ from anyio.abc import AsyncResource
 from dandi.consts import known_instances
 from dandi.dandiapi import DandiAPIClient, RemoteAsset
 from dandi.dandiapi import RemoteDandiset as SyncRemoteDandiset
-from dandi.dandiapi import Version
+from dandi.dandiapi import RemoteZarrAsset, Version
 import httpx
 
 from .aioutil import arequest
@@ -173,6 +173,12 @@ class RemoteDandiset(SyncRemoteDandiset):
             async for item in ait:
                 metadata = await self.aclient.get(f"/assets/{item['asset_id']}/")
                 yield RemoteAsset.from_data(self, item, metadata)
+
+    async def aget_zarr_assets(self) -> AsyncGenerator[RemoteZarrAsset, None]:
+        async with aclosing(self.aget_assets()) as ait:
+            async for asset in ait:
+                if isinstance(asset, RemoteZarrAsset):
+                    yield asset
 
     async def aget_asset_by_path(self, path: str) -> RemoteAsset:
         async with aclosing(

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -25,7 +25,7 @@ from identify.identify import tags_from_filename
 
 from .adandi import RemoteDandiset
 from .adataset import AsyncDataset
-from .aioutil import TextProcess, arequest, open_git_annex
+from .aioutil import TextProcess, arequest, aruncmd, open_git_annex
 from .annex import AsyncAnnex
 from .config import BackupConfig
 from .consts import USER_AGENT
@@ -432,8 +432,12 @@ async def async_assets(
                             partial(clone, source=src, path=ds.pathobj / asset_path)
                         )
                         if config.zarr_gh_org is not None:
-                            await anyio.run_process(
-                                ["git", "remote", "rename", "origin", "github"],
+                            await aruncmd(
+                                "git",
+                                "remote",
+                                "rename",
+                                "origin",
+                                "github",
                                 cwd=ds.pathobj / asset_path,
                             )
                         log.debug("Finished cloning Zarr to %s", asset_path)

--- a/tools/prepare-partial-zarrs.sh
+++ b/tools/prepare-partial-zarrs.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -eux -o pipefail
+
+backup_root=/mnt/backup/dandi
+dandiset_root="$backup_root/dandisets"
+zarr_root="$backup_root/dandizarrs"
+partial_zarrs="$backup_root/partial-zarrs"
+
+dandiset=000108
+
+zarr_info_file="$(mktemp zarr-info-XXXXXX.json)"
+git_status_file="$(mktemp git-status-XXXXXX.json)"
+
+mkdir -p "$partial_zarrs"
+
+export GIT_AUTHOR_NAME="DANDI User"
+export GIT_AUTHOR_EMAIL="info@dandiarchive.org"
+
+cd "$zarr_root"
+for zarr in *-*-*-*-*
+do
+    echo "[INFO] Checking Zarr $zarr ..."
+    curl -fsSL -O "$zarr_info_file" "https://api.dandiarchive.org/api/zarr/$zarr/"
+    zarr_dandiset="$(jq -r .dandiset "$zarr_info_file")"
+    if [[ "$zarr_dandiset" != "$dandiset" ]]
+    then
+        echo "[INFO] Zarr is for different Dandiset; skipping"
+        continue
+    fi
+    cd "$zarr_root/$zarr"
+    if [ ! -e .dandi/zarr-checksum ]
+    then
+        echo "[INFO] Zarr backup is not complete; resetting"
+        git reset --hard HEAD
+        git clean -dxf
+        echo "[INFO] Moving Zarr to partial-zarrs dir"
+        cd ..
+        mv "$zarr" "$partial_zarrs"
+    else
+        git status --porcelain -uall > "$git_status_file"
+        if [ -s "$git_status_file" ]
+        then
+            echo "[INFO] Zarr backup was not saved; resetting"
+            git reset --hard HEAD
+            git clean -dxf
+            echo "[INFO] Moving Zarr to partial-zarrs dir"
+            cd ..
+            mv "$zarr" "$partial_zarrs"
+        else
+            echo "[INFO] Zarr is backed up; adding to Dandiset dataset"
+            path="$(jq -r .name "$zarr_info_file")"
+            cd "$dandiset_root/$dandiset"
+            datalad clone https://github.com/dandizarrs/"$zarr" "$path"
+            cd "$path"
+            git remote rename origin github
+            datalad_id="$(git config --file .datalad/config --get datalad.dataset.id)"
+            commit_date="$(git show -s --format='%ai')"
+            cd -
+            git submodule add https://github.com/dandizarrs/"$zarr" "$path"
+            git config \
+                --file .gitmodules \
+                --replace-all \
+                submodule."$path".datalad-id \
+                "$datalad_id"
+            GIT_AUTHOR_DATE="$commit_date" datalad save \
+                -m "[backups2datalad] Backed up Zarr $zarr to $path" \
+                "$path" .gitmodules
+        fi
+    fi
+done


### PR DESCRIPTION
For #213.

This PR adds a `backups2datalad backup-zarrs [-P <partial-dir>] [-w <workers>] <dandiset>` subcommand that goes through all of the Zarrs of the given Dandiset one by one, backing them up and adding them to the Dandiset dataset individually.  In order to keep track of which Zarrs have been completely backed up, Zarrs that are in-progress are stored in a "partial dir" (default: `$backup_root/partial-zarrs`) and then moved to dandizarrs once the backup is complete, before cloning to the Dandiset dataset.  A shell script `prepare-partial-zarrs.sh` is also included for identifying any Zarrs in dandizarrs that are not completely backed up and moving them to partial-zarrs, while also adding any complete Zarr backups to the Dandiset dataset; this script should be run before running `backup-zarrs`.