### PR TITLE
assets/ ap: Request larger (1000 instead of default 100) page_size

### DIFF
--- a/tools/backups2datalad/adandi.py
+++ b/tools/backups2datalad/adandi.py
@@ -168,7 +168,7 @@ class RemoteDandiset(SyncRemoteDandiset):
         async with aclosing(
             self.aclient.paginate(
                 f"{self.version_api_path}assets/",
-                params={"order": "created", "metadata": "1"},
+                params={"order": "created", "metadata": "1", "page_size": "1000"},
             )
         ) as ait:
             async for item in ait:
@@ -185,7 +185,7 @@ class RemoteDandiset(SyncRemoteDandiset):
         async with aclosing(
             self.aclient.paginate(
                 f"{self.version_api_path}assets/",
-                params={"path": path, "metadata": "1"},
+                params={"path": path, "metadata": "1", "page_size": "1000"},
             )
         ) as ait:
             async for item in ait:


### PR DESCRIPTION
	1: curl --silent https://api.dandiarchive.org/api/dandisets/000026/versions/draft/assets/?metadata=1&order=created&page=1&page_size=1000
				Mean        Std.Dev.    Min         Median      Max
	real        1.413       0.123       1.279       1.384       1.577
	user        0.021       0.002       0.018       0.021       0.024
	sys         0.010       0.004       0.005       0.012       0.014

	1: curl --silent https://api.dandiarchive.org/api/dandisets/000026/versions/draft/assets/?metadata=1&order=created&page=1&page_size=100
				Mean        Std.Dev.    Min         Median      Max
	real        0.778       0.137       0.647       0.719       0.967
	user        0.010       0.004       0.004       0.011       0.014
	sys         0.012       0.004       0.007       0.011       0.018

so takes x2 longer for x10 more records to be returned for the page 1 -- so x5 benefit.

For later page it is even more than x5 benefit since less than x2 time
(overhead to get to the page)

	1: curl --silent https://api.dandiarchive.org/api/dandisets/000026/versions/draft/assets/?metadata=1&order=created&page=1&page_size=100&page=300
				Mean        Std.Dev.    Min         Median      Max
	real        0.924       0.085       0.811       0.947       1.015
	user        0.017       0.003       0.013       0.017       0.020
	sys         0.003       0.003       0.000       0.003       0.007

	1: curl --silent https://api.dandiarchive.org/api/dandisets/000026/versions/draft/assets/?metadata=1&order=created&page=1&page_size=1000&page=30
				Mean        Std.Dev.    Min         Median      Max
	real        1.572       0.184       1.313       1.680       1.723
	user        0.018       0.002       0.015       0.018       0.021
	sys         0.010       0.004       0.007       0.008       0.015

AFAIK 1000 is the largest page_size we can request ATM.