### PR TITLE
Don't backup if draft `modified` timestamp hasn't advanced

### DIFF
--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -108,17 +108,26 @@ async def main(
     help="Force all assets to be updated, even those whose metadata hasn't changed",
 )
 @click.option(
+    "--gc-assets",
+    is_flag=True,
+    default=None,
+    help=(
+        "If assets.json contains any assets neither on the server nor in the"
+        " backup, delete them instead of erroring"
+    ),
+)
+@click.option(
     "--tags/--no-tags",
     default=None,
     help="Enable/disable creation of tags for releases  [default: enabled]",
 )
-@click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
 @click.option(
     "--verify-timestamps",
     is_flag=True,
     default=None,
     help="Error if a Dandiset has changed without an update to its timestamp",
 )
+@click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
 async def update_from_backup(
@@ -130,6 +139,7 @@ async def update_from_backup(
     force: Optional[str],
     workers: Optional[int],
     verify_timestamps: Optional[bool],
+    gc_assets: Optional[bool],
 ) -> None:
     async with datasetter:
         if asset_filter is not None:
@@ -142,6 +152,8 @@ async def update_from_backup(
             datasetter.config.workers = workers
         if verify_timestamps is not None:
             datasetter.config.verify_timestamps = verify_timestamps
+        if gc_assets is not None:
+            datasetter.config.gc_assets = gc_assets
         await datasetter.update_from_backup(dandisets, exclude=exclude)
 
 

--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -113,6 +113,12 @@ async def main(
     help="Enable/disable creation of tags for releases  [default: enabled]",
 )
 @click.option("-w", "--workers", type=int, help="Number of workers to run in parallel")
+@click.option(
+    "--verify-timestamps",
+    is_flag=True,
+    default=None,
+    help="Error if a Dandiset has changed without an update to its timestamp",
+)
 @click.argument("dandisets", nargs=-1)
 @click.pass_obj
 async def update_from_backup(
@@ -123,6 +129,7 @@ async def update_from_backup(
     asset_filter: Optional[re.Pattern[str]],
     force: Optional[str],
     workers: Optional[int],
+    verify_timestamps: Optional[bool],
 ) -> None:
     async with datasetter:
         if asset_filter is not None:
@@ -133,6 +140,8 @@ async def update_from_backup(
             datasetter.config.enable_tags = tags
         if workers is not None:
             datasetter.config.workers = workers
+        if verify_timestamps is not None:
+            datasetter.config.verify_timestamps = verify_timestamps
         await datasetter.update_from_backup(dandisets, exclude=exclude)
 
 

--- a/tools/backups2datalad/config.py
+++ b/tools/backups2datalad/config.py
@@ -44,6 +44,7 @@ class BackupConfig(BaseModel):
     workers: int = DEFAULT_WORKERS
     force: Optional[str] = None
     enable_tags: bool = True
+    verify_timestamps: bool = False
 
     class Config:
         # <https://github.com/samuelcolvin/pydantic/issues/1241>

--- a/tools/backups2datalad/config.py
+++ b/tools/backups2datalad/config.py
@@ -45,6 +45,7 @@ class BackupConfig(BaseModel):
     force: Optional[str] = None
     enable_tags: bool = True
     verify_timestamps: bool = False
+    gc_assets: bool = False
 
     class Config:
         # <https://github.com/samuelcolvin/pydantic/issues/1241>

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -140,6 +140,12 @@ class DandiDatasetter(AsyncResource):
         state = ds.get_assets_state()
         if state is None or state.timestamp < dandiset.version.modified:
             changed, zarr_stats = await self.sync_dataset(dandiset, ds, dmanager)
+        elif state.timestamp > dandiset.version.modified:
+            raise RuntimeError(
+                f"Remote Dandiset {dandiset.identifier} has 'modified'"
+                f" timestamp {dandiset.version.modified} BEFORE last-recorded"
+                f" {state.timestamp}"
+            )
         elif dmanager.config.verify_timestamps:
             changed, zarr_stats = await self.sync_dataset(
                 dandiset, ds, dmanager, error_on_change=True

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -180,7 +180,7 @@ class DandiDatasetter(AsyncResource):
         await update_dandiset_metadata(dandiset, ds, log=manager.log)
         await syncer.sync_assets(error_on_change)
         await syncer.prune_deleted(error_on_change)
-        syncer.dump_asset_metadata(error_on_change)
+        syncer.dump_asset_metadata()
         assert syncer.report is not None
         manager.log.debug("Checking whether repository is dirty ...")
         if await ds.is_unclean():

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -58,12 +58,12 @@ class Syncer:
             await self.ds.remove(asset_path)
             self.deleted += 1
 
-    def dump_asset_metadata(self, error_on_change: bool = False) -> None:
+    def dump_asset_metadata(self) -> None:
         self.garbage_assets = self.tracker.prune_metadata()
-        if self.garbage_assets and error_on_change:
+        if self.garbage_assets and not self.config.gc_assets:
             raise UnexpectedChangeError(
                 f"{quantify(self.garbage_assets, 'asset')} garbage-collected"
-                " from assets.json but draft timestamp was not updated on server"
+                " from assets.json"
             )
         self.tracker.dump()
 

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -10,7 +10,7 @@ from .asyncer import Report, async_assets
 from .config import BackupConfig
 from .logging import PrefixedLogger
 from .manager import Manager
-from .util import AssetTracker, quantify
+from .util import AssetTracker, UnexpectedChangeError, quantify
 
 
 @dataclass
@@ -31,10 +31,10 @@ class Syncer:
     def log(self) -> PrefixedLogger:
         return self.manager.log
 
-    async def sync_assets(self) -> None:
+    async def sync_assets(self, error_on_change: bool = False) -> None:
         self.log.info("Syncing assets...")
         self.report = await async_assets(
-            self.dandiset, self.ds, self.manager, self.tracker
+            self.dandiset, self.ds, self.manager, self.tracker, error_on_change
         )
         self.log.info("Asset sync complete!")
         self.log.info("%s added", quantify(self.report.added, "asset"))
@@ -45,16 +45,26 @@ class Syncer:
         )
         self.report.check()
 
-    async def prune_deleted(self) -> None:
+    async def prune_deleted(self, error_on_change: bool = False) -> None:
         for asset_path in self.tracker.get_deleted(self.config):
+            if error_on_change:
+                raise UnexpectedChangeError(
+                    f"Asset {asset_path!r} deleted from Dandiset but timestamp"
+                    " was not updated on server"
+                )
             self.log.info(
                 "%s: Asset is in dataset but not in Dandiarchive; deleting", asset_path
             )
             await self.ds.remove(asset_path)
             self.deleted += 1
 
-    def dump_asset_metadata(self) -> None:
+    def dump_asset_metadata(self, error_on_change: bool = False) -> None:
         self.garbage_assets = self.tracker.prune_metadata()
+        if self.garbage_assets and error_on_change:
+            raise UnexpectedChangeError(
+                f"{quantify(self.garbage_assets, 'asset')} garbage-collected"
+                " from assets.json but draft timestamp was not updated on server"
+            )
         self.tracker.dump()
 
     def get_commit_message(self) -> str:

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -217,3 +217,7 @@ def is_meta_file(path: str, dandiset: bool = False) -> bool:
     if dandiset and root == dandiset_metadata_file:
         return True
     return root in (".dandi", ".datalad", ".git", ".gitattributes", ".gitmodules")
+
+
+class UnexpectedChangeError(Exception):
+    pass

--- a/tools/test_backups2datalad/conftest.py
+++ b/tools/test_backups2datalad/conftest.py
@@ -136,7 +136,8 @@ class SampleDandiset:
             self.text_assets.keys() | self.blob_assets.keys() | self.zarr_assets.keys()
         )
         assert backup_files == (
-            asset_set | {dandiset_metadata_file, ".dandi/assets.json"}
+            asset_set
+            | {dandiset_metadata_file, ".dandi/assets.json", ".dandi/assets-state.json"}
         )
         with (backup_ds.pathobj / ".dandi" / "assets.json").open() as fp:
             assert {asset["path"] for asset in json.load(fp)} == asset_set

--- a/tools/test_backups2datalad/test_commands.py
+++ b/tools/test_backups2datalad/test_commands.py
@@ -9,9 +9,10 @@ from datalad.api import Dataset
 from datalad.tests.utils_pytest import assert_repo_status
 import numpy as np
 import pytest
+from test_util import GitRepo
 
 from backups2datalad.__main__ import main
-from backups2datalad.adataset import AsyncDataset
+from backups2datalad.adataset import AssetsState, AsyncDataset
 from backups2datalad.config import BackupConfig, Remote, ResourceConfig
 from backups2datalad.logging import log as plog
 from backups2datalad.manager import Manager
@@ -52,6 +53,10 @@ async def test_backup_command(text_dandiset: SampleDandiset, tmp_path: Path) -> 
     assert_repo_status(tmp_path / "ds")
     ds = Dataset(tmp_path / "ds" / text_dandiset.dandiset_id)
     await text_dandiset.check_backup(ds)
+    repo = GitRepo(ds.pathobj)
+    state = AssetsState.parse_raw(repo.get_blob("HEAD", ".dandi/assets-state.json"))
+    d = await text_dandiset.client.get_dandiset(text_dandiset.dandiset_id, "draft")
+    assert state.timestamp == d.version.modified
 
 
 async def test_populate(new_dandiset: SampleDandiset, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #239.

This PR makes the following changes:

* When backing up the draft version of a Dandiset, the draft's `modified` timestamp is now stored in `.dandi/assets-state.json` at the end of the backup.  Intermediate commits made along the way store the `modified` timestamp of the most recent asset at that point.
* When starting a backup of the draft version of a Dandiset, if `.dandi/assets-state.json` exists and the timestamp within is not earlier than the draft's current `modified` date, no backup is performed.
* When backing up a published version of a Dandiset, the version's `created` timestamp is now stored in `.dandi/assets-state.json`.
* A `--verify-timestamps` flag has been added to `update-from-backup`; when given, if a backup would be skipped due to timestamps, the backup is instead run, and an error occurs if anything would be changed.
* If there is any asset metadata that needs to be "garbage collected," an error is emitted unless the `--gc-assets` flag is passed to `update-from-backup`.