### PR TITLE
Uninstall submodules after committing

### DIFF
--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -325,10 +325,14 @@ class AsyncDataset:
         subdatasets = await self.get_subdatasets(
                     result_xfm='relpaths',
                     state="present")
-        log.debug("Will uninstall %d subdatasets", len(subdatasets))
-        res = await anyio.to_thread.run_sync(
-            partial(self.ds.drop, what='datasets', recursive=True, path=subdatasets, reckless='kill'))
-        assert all(r['status'] == 'ok' for r in res)
+        if subdatasets:
+            log.debug("Will uninstall %d subdatasets", len(subdatasets))
+            res = await anyio.to_thread.run_sync(
+                partial(self.ds.drop, what='datasets', recursive=True, path=subdatasets, reckless='kill'))
+            assert all(r['status'] == 'ok' for r in res)
+        else:
+            # yet another case where [] is treated as None?
+            log.debug("No subdatasets to uninstall")
 
     async def update_submodule(self, path: str, commit_hash: str) -> None:
         await aruncmd(

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -299,6 +299,30 @@ class AsyncDataset:
         path.parent.mkdir(exist_ok=True)
         path.write_text(state.json(indent=4) + "\n")
 
+    async def uninstall_submodules(self) -> None:
+        await aruncmd(
+            "datalad",
+            "foreach-dataset",
+            "-s",
+            "-Jauto",
+            "--cmd-type",
+            "eval",
+            "--chpwd",
+            "pwd",
+            "ds.uninstall(check=False)",
+            cwd=self.path,
+        )
+
+    async def update_submodule(self, path: str, commit_hash: str) -> None:
+        await aruncmd(
+            "git",
+            "update-index",
+            "--index-info",
+            "-z",
+            cwd=self.path,
+            input=f"160000 commit {commit_hash}\t{path}\0".encode("utf-8"),
+        )
+
 
 class ObjectType(Enum):
     COMMIT = "commit"

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -332,8 +332,9 @@ class AsyncDataset:
         await aruncmd(
             "git",
             "update-index",
-            "--index-info",
             "-z",
+            # apparently must be the last argument!
+            "--index-info",
             cwd=self.path,
             input=f"160000 commit {commit_hash}\t{path}\0".encode("utf-8"),
         )

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -270,7 +270,7 @@ class AsyncDataset:
                     try:
                         zarr_stat = substats[zarr_id]
                     except KeyError:
-                        assert config.zarr_root
+                        assert config.zarr_root is not None
                         zarr_ds = AsyncDataset(config.zarr_root / zarr_id)
                         # here we assume that HEAD among dandisets is the same as of
                         # submodule, which might not necessarily be the case.

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -325,8 +325,10 @@ class AsyncDataset:
         subdatasets = await self.get_subdatasets(
                     result_xfm='relpaths',
                     state="present")
-        await anyio.to_thread.run_sync(
-            partial(self.ds.drop, path=subdatasets, reckless='kill'))
+        log.debug("Will uninstall %d subdatasets", len(subdatasets))
+        res = await anyio.to_thread.run_sync(
+            partial(self.ds.drop, what='datasets', recursive=True, path=subdatasets, reckless='kill'))
+        assert all(r['status'] == 'ok' for r in res)
 
     async def update_submodule(self, path: str, commit_hash: str) -> None:
         await aruncmd(

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -264,7 +264,7 @@ class AsyncDataset:
                 if filestat.type is ObjectType.COMMIT:
                     # this zarr should not be present locally as a submodule
                     # so we should get its id from its information in submodules
-                    sub_info = await self.get_submodules(path=path)
+                    sub_info = await self.get_subdatasets(path=path)
                     assert len(sub_info) == 1  # must be known
                     zarr_id = Path(sub_info[0]['gitmodule_url']).name
                     try:
@@ -309,20 +309,20 @@ class AsyncDataset:
         path.parent.mkdir(exist_ok=True)
         path.write_text(state.json(indent=4) + "\n")
 
-    async def get_submodules(self, **kwargs: Any) -> list:
+    async def get_subdatasets(self, **kwargs: Any) -> list:
         return await anyio.to_thread.run_sync(
             partial(self.ds.subdatasets,
                     result_renderer=None,
                     **kwargs))
 
-    async def uninstall_submodules(self) -> None:
+    async def uninstall_subdatasets(self) -> None:
         # dropping all dandisets is not trivial :-/
         # https://github.com/datalad/datalad/issues/7013
         #  --reckless kill is not working
         # https://github.com/datalad/datalad/issues/6933#issuecomment-1239402621
         #   '*' pathspec is not supported
         # so could resort to this ad-hoc way but we might want just to pair
-        subdatasets = await self.get_submodules(
+        subdatasets = await self.get_subdatasets(
                     result_xfm='relpaths',
                     state="present")
         await anyio.to_thread.run_sync(

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -213,6 +213,11 @@ async def aruncmd(
     else:
         attrs = ""
     log.debug("Running: %s%s", shlex.join(argstrs), attrs)
+    # Note: stdout/err will be output as ran and not along with the
+    # exception if check was not set to False and command exits with
+    # non-0 status leading to CalledProcessError -- hard to associate
+    # the output produced by the command (might be an error) with the
+    # failed run/exception.
     kwargs.setdefault("stdout", None)
     kwargs.setdefault("stderr", None)
     return await anyio.run_process(argstrs, **kwargs)

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -538,11 +538,10 @@ async def async_assets(
                         )
                         dm.report.downloaded += 1
                         dm.report.updated += 1
-                        zds = AsyncDataset(ds.pathobj / asset_path)
-                        if manager.config.zarr_gh_org is not None:
-                            await zds.update(how="ff-only", sibling="github")
-                        else:
-                            await zds.update(how="ff-only")
+                        assert zarrlink.commit_hash is not None
+                        await ds.update_submodule(
+                            asset_path, commit_hash=zarrlink.commit_hash
+                        )
                         manager.log.debug("Finished updating Zarr at %s", asset_path)
 
             if dandiset.version_id == "draft":

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -480,7 +480,11 @@ class DandiDatasetter(AsyncResource):
                 )
                 ds.assert_no_duplicates_in_gitmodules()
                 log.debug("Zarr %s: Changes saved", asset.zarr)
-
+                # now that we have as a subdataset and know that it is all good, uninstall that subdataset
+                await anyio.to_thread.run_sync(
+                    partial(ds.ds.drop,
+                            what="datasets", recursive=True, path=[asset.path], reckless='kill'))
+                log.debug("Zarr %s: uninstalled", asset.zarr)
         report = await pool_amap(
             dobackup, d.aget_zarr_assets(), workers=self.config.workers
         )

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -201,6 +201,9 @@ class DandiDatasetter(AsyncResource):
             manager.log.debug("Repository is clean")
             if syncer.report.commits == 0:
                 manager.log.info("No changes made to repository")
+        manager.log.info("Uninstalling submodules")
+        await ds.uninstall_submodules()
+        manager.log.info("Finished uninstalling submodules")
         manager.log.debug("Running `git gc`")
         await ds.gc()
         manager.log.debug("Finished running `git gc`")

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -160,7 +160,7 @@ class DandiDatasetter(AsyncResource):
         await self.tag_releases(
             dandiset, ds, push=self.config.gh_org is not None, log=dmanager.log
         )
-        stats, _ = await ds.get_stats(cache=zarr_stats)
+        stats, _ = await ds.get_stats(config=dmanager.config, cache=zarr_stats)
         if self.config.gh_org is not None:
             if changed:
                 dmanager.log.info("Pushing to sibling")
@@ -218,7 +218,7 @@ class DandiDatasetter(AsyncResource):
         ds_stats: list[DatasetStats] = []
         async for d in self.get_dandisets(dandiset_ids, exclude=exclude):
             ds = AsyncDataset(self.config.dandiset_root / d.identifier)
-            stats, zarrstats = await ds.get_stats()
+            stats, zarrstats = await ds.get_stats(config=self.config)
             await self.manager.set_dandiset_description(d, stats)
             for zarr_id, zarr_stat in zarrstats.items():
                 await self.manager.set_zarr_description(zarr_id, zarr_stat)

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -480,11 +480,19 @@ class DandiDatasetter(AsyncResource):
                 )
                 ds.assert_no_duplicates_in_gitmodules()
                 log.debug("Zarr %s: Changes saved", asset.zarr)
-                # now that we have as a subdataset and know that it is all good, uninstall that subdataset
+                # now that we have as a subdataset and know that it is all good,
+                # uninstall that subdataset
                 await anyio.to_thread.run_sync(
-                    partial(ds.ds.drop,
-                            what="datasets", recursive=True, path=[asset.path], reckless='kill'))
+                    partial(
+                        ds.ds.drop,
+                        what="datasets",
+                        recursive=True,
+                        path=[asset.path],
+                        reckless="kill",
+                    )
+                )
                 log.debug("Zarr %s: uninstalled", asset.zarr)
+
         report = await pool_amap(
             dobackup, d.aget_zarr_assets(), workers=self.config.workers
         )

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -202,7 +202,7 @@ class DandiDatasetter(AsyncResource):
             if syncer.report.commits == 0:
                 manager.log.info("No changes made to repository")
         manager.log.info("Uninstalling submodules")
-        await ds.uninstall_submodules()
+        await ds.uninstall_subdatasets()
         manager.log.info("Finished uninstalling submodules")
         manager.log.debug("Running `git gc`")
         await ds.gc()

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -63,7 +63,7 @@ class Syncer:
         self.garbage_assets = self.tracker.prune_metadata()
         if self.garbage_assets and not self.config.gc_assets:
             # to ease troubleshooting, let's list some which were GCed
-            listing = ', '.join(self.garbage_assets[:3])
+            listing = ", ".join(self.garbage_assets[:3])
             if len(self.garbage_assets) > 3:
                 listing += f" and {len(self.garbage_assets) - 3} more."
             raise UnexpectedChangeError(

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from dandi.dandiapi import RemoteDandiset
@@ -20,7 +20,8 @@ class Syncer:
     ds: AsyncDataset
     tracker: AssetTracker
     deleted: int = 0
-    garbage_assets: int = 0
+    # value of garbage_assets will be assigned but to pacity mypy - assign factory
+    garbage_assets: list[str] = field(default_factory=list)
     report: Optional[Report] = None
 
     @property
@@ -61,9 +62,13 @@ class Syncer:
     def dump_asset_metadata(self) -> None:
         self.garbage_assets = self.tracker.prune_metadata()
         if self.garbage_assets and not self.config.gc_assets:
+            # to ease troubleshooting, let's list some which were GCed
+            listing = ', '.join(self.garbage_assets[:3])
+            if len(self.garbage_assets) > 3:
+                listing += f" and {len(self.garbage_assets) - 3} more."
             raise UnexpectedChangeError(
-                f"{quantify(self.garbage_assets, 'asset')} garbage-collected"
-                " from assets.json"
+                f"{quantify(len(self.garbage_assets), 'asset')} garbage-collected"
+                f" from assets.json: {listing}"
             )
         self.tracker.dump()
 
@@ -79,7 +84,7 @@ class Syncer:
             msgparts.append(f"{quantify(self.deleted, 'file')} deleted")
         if self.garbage_assets:
             msgparts.append(
-                f"{quantify(self.garbage_assets, 'asset')} garbage-collected"
+                f"{quantify(len(self.garbage_assets), 'asset')} garbage-collected"
                 " from .dandi/assets.json"
             )
         if futures := self.tracker.future_qty:

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -20,7 +20,7 @@ class Syncer:
     ds: AsyncDataset
     tracker: AssetTracker
     deleted: int = 0
-    # value of garbage_assets will be assigned but to pacity mypy - assign factory
+    # value of garbage_assets will be assigned but to pacify mypy - assign factory
     garbage_assets: list[str] = field(default_factory=list)
     report: Optional[Report] = None
 

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -83,12 +83,12 @@ class AssetTracker:
                 self.asset_metadata.pop(apath, None)
                 yield apath
 
-    def prune_metadata(self) -> int:
-        pruned = 0
+    def prune_metadata(self) -> list[str]:
+        pruned = []
         for path in list(self.asset_metadata):
             if path not in self.remote_assets:
                 self.asset_metadata.pop(path)
-                pruned += 1
+                pruned.append(path)
         return pruned
 
     def dump(self) -> None:

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -119,9 +119,15 @@ def dataset_files(dspath: Path) -> Iterator[str]:
             yield str(p.relative_to(dspath))
         elif p.is_dir():
             if (p / ".git").exists():
+                # installed subdataset (or not even added/known yet)
                 yield str(p.relative_to(dspath))
             else:
                 files.extend(p.iterdir())
+    # there could be uninstalled, such as .zarr/ subdatasets, report them as well
+    for p in Dataset(dspath).subdatasets(
+        result_xfm="relpaths", state="absent", result_renderer=None
+    ):
+        yield p
 
 
 def is_interactive() -> bool:

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -127,7 +127,7 @@ def dataset_files(dspath: Path) -> Iterator[str]:
     for p in Dataset(dspath).subdatasets(
         result_xfm="relpaths", state="absent", result_renderer=None
     ):
-        yield p
+        yield str(p)
 
 
 def is_interactive() -> bool:

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -473,7 +473,7 @@ async def sync_zarr(
             manager.log.info("no changes; not committing")
         if link is not None:
             manager.log.info("Counting up files ...")
-            link.stats = (await ds.get_stats())[0]
+            link.stats = (await ds.get_stats(config=manager.config))[0]
             manager.log.info("Done counting up files")
             if manager.gh is not None:
                 await manager.set_zarr_description(asset.zarr, link.stats)

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -16,6 +16,7 @@ from dandi.dandiapi import RemoteZarrAsset
 from pydantic import BaseModel
 
 from .adataset import AsyncDataset, DatasetStats
+from .aioutil import areadcmd
 from .annex import AsyncAnnex
 from .logging import PrefixedLogger
 from .manager import Manager
@@ -48,6 +49,7 @@ class ZarrLink:
     timestamp: Optional[datetime]
     asset_paths: list[str]
     stats: Optional[DatasetStats] = None
+    commit_hash: Optional[str] = None
 
 
 @dataclass
@@ -475,3 +477,6 @@ async def sync_zarr(
             manager.log.info("Done counting up files")
             if manager.gh is not None:
                 await manager.set_zarr_description(asset.zarr, link.stats)
+            link.commit_hash = await areadcmd(
+                "git", "show", "-s", "--format=%H", cwd=ds.path
+            )

--- a/tools/test_backups2datalad/conftest.py
+++ b/tools/test_backups2datalad/conftest.py
@@ -161,11 +161,12 @@ class SampleDandiset:
     async def check_all_zarrs(
         self, backup_ds: Dataset, zarr_root: Optional[Path] = None
     ) -> PopulateManifest:
-        submodules = {
-            sm["path"].relative_to(backup_ds.pathobj).as_posix(): sm
-            for sm in backup_ds.repo.get_submodules_()
+        subdatasets = {
+            sds["path"].relative_to(backup_ds.pathobj).as_posix(): sds
+            for sds in backup_ds.repo.get_submodules_()
         }
-
+        if subdatasets:
+            import pdb; pdb.set_trace()
         zarr_keys2blobs: dict[str, bytes] = {}
         if self.zarr_assets:
             assert zarr_root is not None
@@ -177,15 +178,16 @@ class SampleDandiset:
                 except NotFoundError:
                     # Happens when Zarr is empty?
                     checksum = None
-                assert path in submodules
-                submod = submodules.pop(path)
-                assert submod["gitmodule_url"] == str(zarr_ds.pathobj)
-                assert submod["type"] == "dataset"
-                assert submod["gitshasum"] == zarr_ds.repo.format_commit("%H")
+                assert path in subdatasets
+                subds = subdatasets.pop(path)
+                assert subds["gitmodule_url"] == str(zarr_ds.pathobj)
+                assert subds["type"] == "dataset"
+                assert subds["gitshasum"] == zarr_ds.repo.format_commit("%H")
+                assert subds["state"] == "absent"  # we should have them uninstalled in the dataset
                 zarr_keys2blobs.update(
                     self.check_zarr_backup(zarr_ds, entries, checksum)
                 )
-        assert not submodules
+        assert not subdatasets
         return PopulateManifest(zarr_keys2blobs)
 
     def check_zarr_backup(

--- a/tools/test_backups2datalad/conftest.py
+++ b/tools/test_backups2datalad/conftest.py
@@ -165,8 +165,6 @@ class SampleDandiset:
             sds["path"].relative_to(backup_ds.pathobj).as_posix(): sds
             for sds in backup_ds.repo.get_submodules_()
         }
-        if subdatasets:
-            import pdb; pdb.set_trace()
         zarr_keys2blobs: dict[str, bytes] = {}
         if self.zarr_assets:
             assert zarr_root is not None

--- a/tools/test_backups2datalad/conftest.py
+++ b/tools/test_backups2datalad/conftest.py
@@ -181,7 +181,9 @@ class SampleDandiset:
                 assert subds["gitmodule_url"] == str(zarr_ds.pathobj)
                 assert subds["type"] == "dataset"
                 assert subds["gitshasum"] == zarr_ds.repo.format_commit("%H")
-                assert subds["state"] == "absent"  # we should have them uninstalled in the dataset
+                assert (
+                    subds["state"] == "absent"
+                )  # we should have them uninstalled in the dataset
                 zarr_keys2blobs.update(
                     self.check_zarr_backup(zarr_ds, entries, checksum)
                 )

--- a/tools/test_backups2datalad/conftest.py
+++ b/tools/test_backups2datalad/conftest.py
@@ -162,8 +162,8 @@ class SampleDandiset:
         self, backup_ds: Dataset, zarr_root: Optional[Path] = None
     ) -> PopulateManifest:
         subdatasets = {
-            sds["path"].relative_to(backup_ds.pathobj).as_posix(): sds
-            for sds in backup_ds.repo.get_submodules_()
+            Path(sds["path"]).relative_to(backup_ds.pathobj).as_posix(): sds
+            for sds in backup_ds.subdatasets(state="any", result_renderer=None)
         }
         zarr_keys2blobs: dict[str, bytes] = {}
         if self.zarr_assets:

--- a/tools/test_backups2datalad/test_commands.py
+++ b/tools/test_backups2datalad/test_commands.py
@@ -79,7 +79,13 @@ async def test_backup_command(text_dandiset: SampleDandiset, tmp_path: Path) -> 
     )
     assert r.exit_code == 0, show_result(r)
     assert_repo_status(tmp_path / "ds")
-    assert repo.get_commitish_hash("HEAD") == last_commit
+
+    # see above comment about "random" server behavior
+    if state.timestamp < d.version.modified:
+        assert repo.get_commitish_hash("HEAD^") == last_commit
+        assert repo.get_commit_subject("HEAD").endswith("Only some metadata updates")
+    else:
+        assert repo.get_commitish_hash("HEAD") == last_commit
 
 
 async def test_populate(new_dandiset: SampleDandiset, tmp_path: Path) -> None:

--- a/tools/test_backups2datalad/test_zarr.py
+++ b/tools/test_backups2datalad/test_zarr.py
@@ -70,7 +70,7 @@ async def test_backup_zarr(new_dandiset: SampleDandiset, tmp_path: Path) -> None
     assert gitrepo.get_commit_count() == 3
     assert gitrepo.get_commit_subject("HEAD") == "[backups2datalad] 2 files added"
 
-    assert await AsyncDataset(ds.pathobj).get_stats() == (
+    assert await AsyncDataset(ds.pathobj).get_stats(config=di.config) == (
         DatasetStats(files=6, size=1535),
         {asset.zarr: DatasetStats(files=5, size=1516)},
     )


### PR DESCRIPTION
Closes #256.

TODO:

- [x] `AsyncDataset.get_stats()` needs to be updated to no longer traverse the subdatasets within the superdataset; instead, it needs to get the Zarr ID by parsing the URL from `.gitmodules` and then traverse the Zarr dataset with that ID in `zarr_root`.  This will involved passing the `Manager` or `BackupConfig` to the method.
- [x] The tests need to be updated: `SampleDandiset.check_backup()` and related methods in `conftest.py` need to check that the Zarr subdatasets are present but not cloned in the Dandiset datasets.
- On drogon, the Zarr subdatasets need to be un-cloned from 000108 (and any other datasets that use Zarrs; I think there's at least one) before running the script on it again.
    - [x] 000108   (running `datalad foreach-dataset --jobs 10 -s --cmd-type eval -R 1 --chpwd pwd 'ds.uninstall(check=False, recursive=False)'`)  
    - [x] TODO others whenever code is ready, so far it is only 1 more: 
   
```shell
(dandisets) dandi@drogon:/mnt/backup/dandi/dandisets$ ls -ld 00*/.gitmodules
-rw-r--r-- 1 dandi dandi 1404521 Aug 17 09:53 000108/.gitmodules
-rw-r--r-- 1 dandi dandi     215 Jun 15 16:04 000243/.gitmodules
```