### PR TITLE
BF(workaround): get back .dandi/ after "move"

### DIFF
--- a/tools/backups2datalad/__main__.py
+++ b/tools/backups2datalad/__main__.py
@@ -382,6 +382,19 @@ async def populate(dirpath: Path, backup_remote: str, pathtype: str, jobs: int) 
                 backup_remote,
                 path=dirpath,
             )
+            # poor man solution for now: ocopy back possible annexed
+            # .dandi/assets.json etc content # which could happen in
+            # dandisets heavy on assets and thus making huge assets.json
+            # which we need to keep in annex (such as 000026)
+            await call_annex_json(
+                "get",
+                "-c",
+                "annex.retry=3",
+                "--jobs",
+                str(jobs),
+                ".dandi",
+                path=dirpath,
+            )
         except RuntimeError as e:
             i += 1
             if i < 5:


### PR DESCRIPTION
It is ugly solution for something we could have done more elegantly with either types of remotes for annex + "annex sync"  or just metadata annotation for .dandi files and using "move --not metadata=precious" or something like that. For now I will just keep it as this - get that file back after "move".

Let's see if it breaks any tests. If not - I will just merge and proceed since change is minor but keeps cron job errorring out