### PR TITLE
OPT: no need to recount zarr stats if there is no change and we had report uploaded alread

### DIFF
--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -472,7 +472,10 @@ async def sync_zarr(
                 link.timestamp = commit_ts
         else:
             manager.log.info("no changes; not committing")
-        if link is not None:
+        # count up stats if there is a change or it was not counted before
+        if link is not None and (
+            report or not ds.ds.config.get("dandi.github-description", None)
+        ):
             manager.log.info("Counting up files ...")
             link.stats = (await ds.get_stats(config=manager.config))[0]
             manager.log.info("Done counting up files")


### PR DESCRIPTION
current run has been running for over a day and it seems that it does nothing in effect - nothing is pushed etc, but it does do counting up:

	2022-09-27T09:39:11-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 8b503f47-3917-4368-80bd-81aa57157ba9: Counting up files ...
	2022-09-27T09:39:11-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 9726fd78-8b1e-4a40-bec7-7d2fff48359c: no changes; not committing
	2022-09-27T09:39:11-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 9726fd78-8b1e-4a40-bec7-7d2fff48359c: Counting up files ...
	2022-09-27T09:39:27-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 03bf6866-8324-4ebf-b2ed-3f30f3ccebaf: backup up to date
	2022-09-27T09:39:27-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 03bf6866-8324-4ebf-b2ed-3f30f3ccebaf: no changes; not committing
	2022-09-27T09:39:27-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 03bf6866-8324-4ebf-b2ed-3f30f3ccebaf: Counting up files ...
	2022-09-27T09:39:33-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 85141deb-40b0-44cb-a7a8-6ecfe9c69a32: backup up to date
	2022-09-27T09:39:33-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 85141deb-40b0-44cb-a7a8-6ecfe9c69a32: no changes; not committing
	2022-09-27T09:39:33-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 85141deb-40b0-44cb-a7a8-6ecfe9c69a32: Counting up files ...
	2022-09-27T09:39:42-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 705af779-36a5-4a4c-b081-ca72509a6b0c: backup up to date
	2022-09-27T09:39:42-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 705af779-36a5-4a4c-b081-ca72509a6b0c: no changes; not committing
	2022-09-27T09:39:42-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 705af779-36a5-4a4c-b081-ca72509a6b0c: Counting up files ...
	2022-09-27T09:39:45-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr b8c5348b-ca68-42e3-b2db-603189f2b303: Done counting up files
	2022-09-27T09:39:46-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr e51ad565-1b89-4686-87a5-d9d680373a12: Done counting up files
	2022-09-27T09:39:55-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 0f13f230-4e1b-41b0-81ff-70450af91455: Done counting up files
	2022-09-27T09:39:58-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr fc6c03f2-7be3-4e13-a3b1-5810455de47b: Done counting up files
	2022-09-27T09:40:08-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 9126590f-191a-44d3-91fd-934999b7222d: backup up to date
	2022-09-27T09:40:09-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 9126590f-191a-44d3-91fd-934999b7222d: no changes; not committing
	2022-09-27T09:40:09-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 9126590f-191a-44d3-91fd-934999b7222d: Counting up files ...
	2022-09-27T09:40:15-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr e8b130c7-fca9-4f0d-9690-3e4e189314bd: Done counting up files
	2022-09-27T09:40:17-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr a87adc4e-8ad1-4329-a9ce-19d055e0aeeb: Done counting up files
	2022-09-27T09:40:19-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr ffaee4f2-f307-43cd-a035-c0dbe00b1d51: Done counting up files
	2022-09-27T09:40:27-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr a494a116-fbe0-474a-9e94-9f5bf72ab48c: Done counting up files
	2022-09-27T09:40:31-0400 [INFO    ] backups2datalad: Dandiset 000108: Zarr 1b92bf47-7c6c-4b9f-8f4d-c1653a3d3b3e: Done counting up files

and I think there is no reason to count up if no change and we previously uploaded. Of cause idelly we should have may be stored just the commit instead of the stats string in that github-description since now we could interrupt and end up with not up to date stats, but IMHO it is ok since unlikely.

@jwodder -- am I correct in assuming the purpose of `report` etc?