### PR TITLE
RF+BF: use/cache stats for every get_stats, not only for sub-zarrs

### DIFF
--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -25,7 +25,7 @@ import httpx
 from identify.identify import tags_from_filename
 
 from .adandi import RemoteDandiset
-from .adataset import AssetsState, AsyncDataset, DatasetStats
+from .adataset import AssetsState, AsyncDataset
 from .aioutil import TextProcess, arequest, aruncmd, open_git_annex
 from .annex import AsyncAnnex
 from .config import BackupConfig
@@ -66,7 +66,6 @@ class Report:
     failed: int = 0
     hash_mismatches: int = 0
     old_unhashed: int = 0
-    zarr_stats: dict[str, DatasetStats] = field(default_factory=dict)
 
     def update(self, other: Report) -> None:
         self.commits += other.commits
@@ -495,9 +494,7 @@ async def async_assets(
             timestamp = dm.last_timestamp
             for zarr_id, zarrlink in dm.zarrs.items():
                 # We've left the task group, so all of the Zarr tasks have
-                # finished and set the timestamps & stats in their links
-                assert zarrlink.stats is not None
-                total_report.zarr_stats[zarr_id] = zarrlink.stats
+                # finished and set the timestamps in link
                 ts = zarrlink.timestamp
                 if ts is not None:
                     timestamp = maxdatetime(timestamp, ts)

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -139,7 +139,7 @@ class DandiDatasetter(AsyncResource):
         dmanager = self.manager.with_sublogger(f"Dandiset {dandiset.identifier}")
         state = ds.get_assets_state()
         if state is None or state.timestamp < dandiset.version.modified:
-            changed, _ = await self.sync_dataset(dandiset, ds, dmanager)
+            changed = await self.sync_dataset(dandiset, ds, dmanager)
         elif state.timestamp > dandiset.version.modified:
             raise RuntimeError(
                 f"Remote Dandiset {dandiset.identifier} has 'modified'"
@@ -147,7 +147,7 @@ class DandiDatasetter(AsyncResource):
                 f" {state.timestamp}"
             )
         elif dmanager.config.verify_timestamps:
-            changed, _ = await self.sync_dataset(
+            changed = await self.sync_dataset(
                 dandiset, ds, dmanager, error_on_change=True
             )
         else:
@@ -173,10 +173,9 @@ class DandiDatasetter(AsyncResource):
         ds: AsyncDataset,
         manager: Manager,
         error_on_change: bool = False,
-    ) -> tuple[bool, dict[str, DatasetStats]]:
+    ) -> bool:
         # Returns:
         # - true iff any changes were committed to the repository
-        # - a mapping from Zarr IDs to their dataset stats
         manager.log.info("Syncing")
         if await ds.is_dirty():
             raise RuntimeError(f"Dirty {dandiset}; clean or save before running")
@@ -206,8 +205,7 @@ class DandiDatasetter(AsyncResource):
         manager.log.debug("Running `git gc`")
         await ds.gc()
         manager.log.debug("Finished running `git gc`")
-        assert syncer.report.zarr_stats is not None
-        return (syncer.report.commits > 0, syncer.report.zarr_stats)
+        return syncer.report.commits > 0
 
     async def update_github_metadata(
         self,
@@ -221,8 +219,8 @@ class DandiDatasetter(AsyncResource):
             await self.manager.set_dandiset_description(d, stats, ds)
 
             for sub_info in await ds.get_subdatasets():
-                # ATM we have only .zarr subdatasets
-                assert sub_info["path"].endswith(".zarr")
+                # ATM we have only .zarr-like subdatasets
+                assert Path(sub_info["path"]).suffix in (".zarr", ".ngff")
                 # here we will rely on get_stats to use cached during above
                 # recursive through subdatasets ds.get_stats call
                 await self.manager.set_zarr_description(

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -473,7 +473,7 @@ async def sync_zarr(
             manager.log.info("no changes; not committing")
         if link is not None:
             manager.log.info("Counting up files ...")
-            link.stats = (await ds.get_stats(config=manager.config))[0]
+            link.stats = await ds.get_stats(config=manager.config)
             manager.log.info("Done counting up files")
             if manager.gh is not None:
                 await manager.set_zarr_description(asset.zarr, link.stats)

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -15,7 +15,7 @@ from botocore import UNSIGNED
 from dandi.dandiapi import RemoteZarrAsset
 from pydantic import BaseModel
 
-from .adataset import AsyncDataset, DatasetStats
+from .adataset import AsyncDataset
 from .annex import AsyncAnnex
 from .logging import PrefixedLogger
 from .manager import Manager
@@ -47,7 +47,6 @@ class ZarrLink:
     zarr_dspath: Path
     timestamp: Optional[datetime]
     asset_paths: list[str]
-    stats: Optional[DatasetStats] = None
     commit_hash: Optional[str] = None
 
 
@@ -472,9 +471,9 @@ async def sync_zarr(
         else:
             manager.log.info("no changes; not committing")
         if link is not None:
-            manager.log.info("Counting up files ...")
-            link.stats = await ds.get_stats(config=manager.config)
-            manager.log.info("Done counting up files")
             if manager.gh is not None:
-                await manager.set_zarr_description(asset.zarr, link.stats)
+                manager.log.info("Counting up files ...")
+                stats = await ds.get_stats(config=manager.config)
+                manager.log.info("Done counting up files")
+                await manager.set_zarr_description(asset.zarr, stats)
             link.commit_hash = await ds.get_commit_hash()

--- a/tools/test_backups2datalad/test_zarr.py
+++ b/tools/test_backups2datalad/test_zarr.py
@@ -70,9 +70,8 @@ async def test_backup_zarr(new_dandiset: SampleDandiset, tmp_path: Path) -> None
     assert gitrepo.get_commit_count() == 3
     assert gitrepo.get_commit_subject("HEAD") == "[backups2datalad] 2 files added"
 
-    assert await AsyncDataset(ds.pathobj).get_stats(config=di.config) == (
-        DatasetStats(files=6, size=1535),
-        {asset.zarr: DatasetStats(files=5, size=1516)},
+    assert await AsyncDataset(ds.pathobj).get_stats(config=di.config) == DatasetStats(
+        files=6, size=1535
     )
 
     log.info("test_backup_zarr: Syncing unmodified Zarr dandiset")


### PR DESCRIPTION
Also removed return of a dict of stats for subdatasets to make code IMHO a little lighter -- no assumption that subdatasets stats only for zarrs (we might get regular subdatasets later).  Had to come up with a helper to reuse to avoid code duplication while updating github metadata.

Fixes part of https://github.com/dandi/dandisets/issues/276