### PR TITLE
BF: use "git commit -a" instead of "datalad save" for when saving updated state

### DIFF
--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -140,7 +140,7 @@ class AsyncDataset:
             env=custom_commit_env(commit_date),
         )
 
-    async def commit_all(
+    async def commit(
         self,
         message: str,
         commit_date: Optional[datetime] = None,
@@ -153,19 +153,16 @@ class AsyncDataset:
         updated states of subdatasets without them being installed in the tree.
         Ref: https://github.com/datalad/datalad/issues/7074
         """
-        await aruncmd(
-            "git",
+        await self.call_git(
             "commit",
-            "-a",
             "-m",
             message,
-            cwd=self.path,
             env=custom_commit_env(commit_date),
         )
         if await self.is_dirty():
             raise RuntimeError(
-                f"{self.path} is still dirty after commit -a. "
-                "Please check if all changes were staged"
+                f"{self.path} is still dirty after committing."
+                "  Please check if all changes were staged."
             )
 
     async def push(self, to: str, jobs: int, data: Optional[str] = None) -> None:
@@ -450,6 +447,7 @@ class AsyncDataset:
             f"submodule.{path}.datalad-id",
             datalad_id,
         )
+        await self.add(".gitmodules")
 
     async def update_submodule(self, path: str, commit_hash: str) -> None:
         await self.call_git(

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -204,7 +204,7 @@ class AsyncDataset:
 
     async def remove(self, path: str) -> None:
         # `path` must be relative to the root of the dataset
-        await self.call_git("rm", path)
+        await self.call_git("rm", "-f", "--ignore-unmatch", "--", path)
 
     async def update(self, how: str, sibling: Optional[str] = None) -> None:
         await anyio.to_thread.run_sync(
@@ -400,10 +400,11 @@ class AsyncDataset:
         except FileNotFoundError:
             return None
 
-    def set_assets_state(self, state: AssetsState) -> None:
+    async def set_assets_state(self, state: AssetsState) -> None:
         path = self.pathobj / AssetsState.PATH
         path.parent.mkdir(exist_ok=True)
         path.write_text(state.json(indent=4) + "\n")
+        await self.add(str(AssetsState.PATH))
 
     async def get_subdatasets(self, **kwargs: Any) -> list:
         return await anyio.to_thread.run_sync(

--- a/tools/backups2datalad/adataset.py
+++ b/tools/backups2datalad/adataset.py
@@ -144,6 +144,8 @@ class AsyncDataset:
         self,
         message: str,
         commit_date: Optional[datetime] = None,
+        paths: Sequence[str | Path] = (),
+        check_dirty: bool = True,
     ) -> None:
         """Use git commit directly, verify that all is committed
 
@@ -157,9 +159,11 @@ class AsyncDataset:
             "commit",
             "-m",
             message,
+            "--",
+            *map(str, paths),
             env=custom_commit_env(commit_date),
         )
-        if await self.is_dirty():
+        if check_dirty and await self.is_dirty():
             raise RuntimeError(
                 f"{self.path} is still dirty after committing."
                 "  Please check if all changes were staged."

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -571,7 +571,7 @@ async def async_assets(
                     manager.log.debug("Checking whether repository is dirty ...")
                     if await ds.is_unclean():
                         manager.log.info("Committing changes")
-                        await ds.save(
+                        await ds.commit_all(
                             message=dm.report.get_commit_message(),
                             commit_date=timestamp,
                         )

--- a/tools/backups2datalad/asyncer.py
+++ b/tools/backups2datalad/asyncer.py
@@ -583,7 +583,7 @@ async def async_assets(
                     manager.log.debug("Checking whether repository is dirty ...")
                     if await ds.is_unclean():
                         manager.log.info("Committing changes")
-                        await ds.commit_all(
+                        await ds.commit(
                             message=dm.report.get_commit_message(),
                             commit_date=timestamp,
                         )

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -479,6 +479,11 @@ class DandiDatasetter(AsyncResource):
                         "github",
                         cwd=ds.pathobj / asset.path,
                     )
+                # Uncomment this if `ds.save()` below is ever changed to
+                # `ds.commit_all()`:
+                # await ds.add_submodule(
+                #     path=asset.path, url=src, datalad_id=await zds.get_datalad_id()
+                # )
                 log.debug("Zarr %s: Finished cloning", asset.zarr)
                 log.debug("Zarr %s: Saving changes to Dandiset dataset", asset.zarr)
                 ds.assert_no_duplicates_in_gitmodules()

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -187,7 +187,7 @@ class DandiDatasetter(AsyncResource):
         await update_dandiset_metadata(dandiset, ds, log=manager.log)
         await syncer.sync_assets(error_on_change)
         await syncer.prune_deleted(error_on_change)
-        syncer.dump_asset_metadata()
+        await syncer.dump_asset_metadata()
         assert syncer.report is not None
         manager.log.debug("Checking whether repository is dirty ...")
         if await ds.is_unclean():
@@ -372,7 +372,7 @@ class DandiDatasetter(AsyncResource):
                 "checkout", "-b", f"release-{dandiset.version_id}", matching[0]
             )
             await update_dandiset_metadata(dandiset, ds, log)
-            ds.set_assets_state(AssetsState(timestamp=dandiset.version.created))
+            await ds.set_assets_state(AssetsState(timestamp=dandiset.version.created))
             log.debug("Committing changes")
             await ds.save(
                 message=f"[backups2datalad] {dandiset_metadata_file} updated",

--- a/tools/backups2datalad/datasetter.py
+++ b/tools/backups2datalad/datasetter.py
@@ -192,7 +192,7 @@ class DandiDatasetter(AsyncResource):
         manager.log.debug("Checking whether repository is dirty ...")
         if await ds.is_unclean():
             manager.log.info("Committing changes")
-            await ds.save(
+            await ds.commit(
                 message=syncer.get_commit_message(),
                 commit_date=dandiset.version.modified,
             )
@@ -374,7 +374,7 @@ class DandiDatasetter(AsyncResource):
             await update_dandiset_metadata(dandiset, ds, log)
             await ds.set_assets_state(AssetsState(timestamp=dandiset.version.created))
             log.debug("Committing changes")
-            await ds.save(
+            await ds.commit(
                 message=f"[backups2datalad] {dandiset_metadata_file} updated",
                 commit_date=dandiset.version.created,
             )
@@ -480,7 +480,7 @@ class DandiDatasetter(AsyncResource):
                         cwd=ds.pathobj / asset.path,
                     )
                 # Uncomment this if `ds.save()` below is ever changed to
-                # `ds.commit_all()`:
+                # `ds.commit()`:
                 # await ds.add_submodule(
                 #     path=asset.path, url=src, datalad_id=await zds.get_datalad_id()
                 # )

--- a/tools/backups2datalad/syncer.py
+++ b/tools/backups2datalad/syncer.py
@@ -58,7 +58,7 @@ class Syncer:
             await self.ds.remove(asset_path)
             self.deleted += 1
 
-    def dump_asset_metadata(self) -> None:
+    async def dump_asset_metadata(self) -> None:
         self.garbage_assets = self.tracker.prune_metadata()
         if self.garbage_assets and not self.config.gc_assets:
             # to ease troubleshooting, let's list some which were GCed
@@ -70,6 +70,7 @@ class Syncer:
                 f" from assets.json: {listing}"
             )
         self.tracker.dump()
+        await self.ds.add(".dandi/assets.json")
 
     def get_commit_message(self) -> str:
         msgparts = []

--- a/tools/backups2datalad/util.py
+++ b/tools/backups2datalad/util.py
@@ -22,6 +22,7 @@ from .logging import PrefixedLogger
 
 if TYPE_CHECKING:
     from .adandi import RemoteAsset, RemoteDandiset
+    from .adataset import AsyncDataset
 
 
 @dataclass
@@ -175,7 +176,7 @@ def assets_eq(remote_assets: list[RemoteAsset], local_assets: list[dict]) -> boo
 
 
 async def update_dandiset_metadata(
-    dandiset: RemoteDandiset, ds: Dataset, log: PrefixedLogger
+    dandiset: RemoteDandiset, ds: AsyncDataset, log: PrefixedLogger
 ) -> None:
     log.info("Updating metadata file")
     (ds.pathobj / dandiset_metadata_file).unlink(missing_ok=True)

--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -494,10 +494,12 @@ async def sync_zarr(
             (ds.pathobj / ".dandi" / ".gitattributes").write_text(
                 "* annex.largefiles=nothing\n"
             )
-            await ds.save(
+            await ds.add(".dandi/.gitattributes")
+            await ds.commit(
                 message="Exclude .dandi/ from git-annex",
-                path=[".dandi/.gitattributes"],
+                paths=[".dandi/.gitattributes"],
                 commit_date=asset.created,
+                check_dirty=False,
             )
         if (zgh := manager.config.zarrs.github_org) is not None:
             manager.log.debug("Creating GitHub sibling")
@@ -530,7 +532,9 @@ async def sync_zarr(
                 commit_ts = asset.created
             else:
                 commit_ts = zsync.last_timestamp
-            await ds.save(message=f"[backups2datalad] {summary}", commit_date=commit_ts)
+            await ds.commit(
+                message=f"[backups2datalad] {summary}", commit_date=commit_ts
+            )
             manager.log.debug("Commit made")
             manager.log.debug("Running `git gc`")
             await ds.gc()


### PR DESCRIPTION
I hope that we have everything already staged so it should just work, but it might be that we would need to add some "git rm" instead of just plain "unlink" if files were removed etc... to be seen!

An alterantive would be to do  datalad save  followed by git commit --amend -a reusing the message etc, but should be done carefully since there might have been no commit so we have to not use --amend...

Hope is that it would address the 2nd part of the
https://github.com/dandi/dandisets/issues/276