### PR TITLE
Test against Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         python-version:
           - '3.8'
           - '3.9'
+          - '3.10'
+          - '3.11'
         noxenv: [test]
         include:
           - python-version: '3.8'


### PR DESCRIPTION
EDIT: Testing against Python 3.11 is delayed due to dependency issues with installing dandi (cf. https://github.com/dandi/dandi-cli/pull/1143).