### PR TITLE
Add lower-level logging of unexpected exceptions

### DIFF
--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -242,15 +242,19 @@ async def stream_null_command(
         buff = ""
         assert p.stdout is not None
         async for text in TextReceiveStream(p.stdout):
-            buff += text
-            while True:
-                try:
-                    i = buff.index("\0")
-                except ValueError:
-                    break
-                else:
-                    yield buff[:i]
-                    buff = buff[i + 1 :]
+            try:
+                buff += text
+                while True:
+                    try:
+                        i = buff.index("\0")
+                    except ValueError:
+                        break
+                    else:
+                        yield buff[:i]
+                        buff = buff[i + 1 :]
+            except BaseException:
+                log.exception("Exception raised while handling output from %s", desc)
+                raise
         if buff:
             yield buff
     log.log(

--- a/tools/backups2datalad/aioutil.py
+++ b/tools/backups2datalad/aioutil.py
@@ -242,16 +242,15 @@ async def stream_null_command(
         buff = ""
         assert p.stdout is not None
         async for text in TextReceiveStream(p.stdout):
+            buff += text
             while True:
                 try:
-                    i = text.index("\0")
+                    i = buff.index("\0")
                 except ValueError:
-                    buff = text
                     break
                 else:
-                    yield buff + text[:i]
-                    buff = ""
-                    text = text[i + 1 :]
+                    yield buff[:i]
+                    buff = buff[i + 1 :]
         if buff:
             yield buff
     log.log(


### PR DESCRIPTION
Part of #293.

I was able to produce an MVCE of the problem (which I reported as a bug in anyio: https://github.com/agronholm/anyio/issues/490).  Apparently, some exception is getting raised inside `stream_null_command()` — either immediately inside it or within something that's using it as a context manager — but I have no idea what that exception might be.  I've added more logging for now.