### PR TITLE
Trigger commit if not changes to zarr but we had only updated time stamp

### DIFF
--- a/tools/backups2datalad/zarr.py
+++ b/tools/backups2datalad/zarr.py
@@ -536,8 +536,11 @@ async def sync_zarr(
             )
             await zsync.run()
         report = zsync.report
-        if report:
-            summary = report.get_summary()
+        if report or await zsync.ds.is_dirty():
+            if report:
+                summary = report.get_summary()
+            else:
+                summary = "No changes to zarr content, some other changes"
             manager.log.info("%s; committing", summary)
             if zsync.last_timestamp is None:
                 commit_ts = asset.created


### PR DESCRIPTION
may be s3 gets something resulting in update but no content change. not entirely sure on the reason though

Tested on /mnt/backup/dandi/dandizarrs/a887df22-1254-46c8-84bc-c11703844978 which now has that commit

Not sure if this wold be ok to as if some operation errors out in syncing zarr that we do not commit (I would assume that exception would bubble up)

Closes #321 