### PR TITLE
Use zarr_checksum package for computing Zarr checksums

### DIFF
--- a/tools/backups2datalad.req.txt
+++ b/tools/backups2datalad.req.txt
@@ -14,3 +14,4 @@ identify ~= 2.0
 linesep ~= 0.4
 packaging
 pydantic ~= 1.8
+zarr_checksum


### PR DESCRIPTION
@AlmightyYakob wrote a package for computing Zarr checksums, including calculating checksums for a tree of individual file checksums, and to ensure consistency among the Dandi code base, it should be used in place of dandi-cli's `ZCTree` class.