### PR TITLE
Capture output from all subcommands and log on failure

### DIFF
--- a/tools/backups2datalad-cron-common
+++ b/tools/backups2datalad-cron-common
@@ -14,7 +14,8 @@ conda activate dandisets-2
 cd "$ds"
 chronic pip install -r tools/backups2datalad.req.txt
 
-export DATALAD_LOG_LEVEL=WARNING  # otherwise too much noise
+: "${DATALAD_LOG_LEVEL:=WARNING}"  # otherwise too much noise
+export DATALAD_LOG_LEVEL
 
 mkdir -p .git/tmp
 


### PR DESCRIPTION
Part of #347.

Note that this won't affect commands run by DataLad; would changing [this setting](https://github.com/dandi/dandisets/blob/21979e2ee56c786906803587ca27e694397757bc/tools/backups2datalad-cron-common#L17) help?