### PR TITLE
Ensure latest version of `backups2datalad` is installed on every run

### DIFF
--- a/tools/backups2datalad-cron-common
+++ b/tools/backups2datalad-cron-common
@@ -11,11 +11,18 @@ backup_root="$(dirname "$ds")"
 source ~/.bashrc-miniconda
 conda activate dandisets-2
 
-cd "$ds"
+if pip show backups2datalad >/dev/null 2>&1
+then
+    # Uninstall backups2datalad so that the subsequent `pip install` will
+    # always install the latest code
+    chronic pip uninstall --yes backups2datalad
+fi
 chronic pip install git+https://github.com/dandi/backups2datalad
 
 : "${DATALAD_LOG_LEVEL:=WARNING}"  # otherwise too much noise
 export DATALAD_LOG_LEVEL
+
+cd "$ds"
 
 mkdir -p .git/tmp
 


### PR DESCRIPTION
The backups are currently failing to back up embargoed Dandisets because the copy of `backups2datalad` in the Conda environment was not upgraded after https://github.com/dandi/backups2datalad/pull/12 was merged.  This is because, when installing from a VCS URL, `pip install` (with or without `--upgrade`) will only update an already-installed package if its version number has increased (regardless of whether any changes have been made to the code), yet `backups2datalad`'s version is constantly at 0.0.0 due to our lack of a need for versioning.

This PR solves the problem by uninstalling `backups2datalad` before running `pip install`, so that the latter will have no choice but to install the latest revision.